### PR TITLE
최종 

### DIFF
--- a/source/receiver/decoder.py
+++ b/source/receiver/decoder.py
@@ -1,23 +1,28 @@
-import json
-import zlib
+# -*- coding: utf-8 -*-
+"""
+zlib‑압축, struct 30 B 포맷 해제 → dict 복원
+포맷·스케일 값은 encoder.py 와 반드시 동일해야 함
+"""
+from __future__ import annotations
+import struct, zlib
+from typing import Dict, Any, Optional
 
-def decompress_data(data: bytes) -> dict:
-    """
-    압축된 바이너리 데이터를 zlib으로 해제 후,
-    JSON 형식으로 파싱하여 dict 형태의 원본 데이터를 반환합니다.
-    
-    복원 실패 시 예외를 처리하고 None을 반환하여 fallback 합니다.
-    """
+_FMT     = "<Ihhhhhhhhhff"
+_SCALES  = (1, 1000, 1000, 1000, 10, 10, 10, 10, 10, 10, 1.0, 1.0)
+
+def decompress_data(buf: bytes) -> Optional[Dict[str, Any]]:
     try:
-        # 1) zlib 해제
-        decompressed_bytes = zlib.decompress(data)
-        
-        # 2) JSON 디코딩
-        json_str = decompressed_bytes.decode('utf-8')
-        original_data = json.loads(json_str)
-        
-        return original_data
+        unpacked = struct.unpack(_FMT, zlib.decompress(buf))
+        ts, ax, ay, az, gx, gy, gz, roll, pitch, yaw, lat, lon = (
+            u / s for u, s in zip(unpacked, _SCALES)
+        )
+        return {
+            "ts": ts,
+            "accel": {"ax": ax, "ay": ay, "az": az},
+            "gyro":  {"gx": gx, "gy": gy, "gz": gz},
+            "angle": {"roll": roll, "pitch": pitch, "yaw": yaw},
+            "gps":   {"lat": lat, "lon": lon},
+        }
     except Exception as e:
-        # 복원 실패 시 예외 로깅 및 fallback 처리
-        print(f"[decompress_data] 복원 실패: {e}")
+        print(f"[decoder] 복원 실패: {e}")
         return None

--- a/source/receiver/packet_reassembler.py
+++ b/source/receiver/packet_reassembler.py
@@ -1,123 +1,56 @@
-import json
-import base64
-import binascii
-from typing import Dict, Optional
+# -*- coding: utf-8 -*-
+"""
+패킷 2 바이트 헤더(seq / total) + payload(≤56 B) 재조립기
+"""
+from __future__ import annotations
+from typing import Dict, Optional, List
 
-#예외임요요
-class PacketReassemblyError(Exception):
-    pass
-
-class PacketFormatError(PacketReassemblyError):
-    pass
-
-class InconsistentPacketDataError(PacketReassemblyError):
-    pass
-
-class DuplicatePacketError(PacketReassemblyError):
-    pass
-
-  # _packets: 수신된 페이로드를 순번(seq)을 키로 하여 저장하는 딕셔너리
-  # _expected_total: 현재 메시지를 구성하는 총 패킷 수
-
-  # str(json) -> json.loads() -> dict -> base64.b64decode() -> bytes -> decoder.py 
+class PacketReassemblyError(Exception):      pass
+class InconsistentPacketError(PacketReassemblyError):  pass
+class DuplicatePacketError(PacketReassemblyError):     pass
+class MissingPacketError(PacketReassemblyError):       pass
 
 class PacketReassembler:
+    def __init__(self) -> None:
+        self._pkt: Dict[int, bytes] = {}
+        self._total: Optional[int]  = None
 
-    def __init__(self):
+    def reset(self) -> None:
+        self._pkt.clear()
+        self._total = None
 
-        self._packets: Dict[int, bytes] = {}
-        self._expected_total: Optional[int] = None
-        print("[Reassembler] 초기화 완료.")
+    # ────────── 프레임 처리 ──────────
+    def process_frame(self, frame: bytes) -> Optional[bytes]:
+        if len(frame) < 3:                       # 2B 헤더 + ≥1B payload
+            raise PacketReassemblyError("프레임 길이 오류")
 
-    def _reset_state(self):  # 내부 상태를 초기화 
+        seq, total = frame[0], frame[1]
+        payload    = frame[2:]
 
-        print(f"[Reassembler] 상태 초기화 (예상 패킷 수: {self._expected_total})이다.")
-        self._packets.clear()
-        self._expected_total = None
+        if total == 0 or not (1 <= seq <= total):
+            raise PacketReassemblyError("헤더 값 오류")
 
-    def process_line(self, line: str) -> Optional[bytes]:
-        """
-        입력된 한 줄의 JSON 문자열(패킷 데이터)을 처리하여 재조립을 시도한다.
-        모든 패킷이 수신되면 완성된 메시지를 bytes 형태로 반환하며, 그렇지 않으면 None을 반환한다.
-        """
-        # 1. JSON 파싱
-        try:
-            data = json.loads(line)
+        # 첫 패킷
+        if self._total is None:
+            self._total = total
+            self._pkt.clear()
+        # 총 패킷 수 불일치
+        elif total != self._total:
+            self.reset()
+            raise InconsistentPacketError("total 값이 바뀌었습니다")
 
-        except json.JSONDecodeError as e:
-            raise PacketFormatError(f"잘못된 JSON 형식이다: {e}") from e
+        # 중복 검사
+        if seq in self._pkt:
+            raise DuplicatePacketError(f"중복 패킷 {seq}")
 
-        # 2. 파싱된 데이터가 딕셔너리인지 확인
-        if not isinstance(data, dict):
-            raise PacketFormatError("파싱된 데이터가 딕셔너리가 아니다.")
+        self._pkt[seq] = payload
 
-        # 3. 필수 필드('seq', 'total', 'payload')를 추출하고 존재, 타입, 값 검증
-        seq = data.get('seq')
-        total = data.get('total')
-
-        payload_b64 = data.get('payload') # 얘가 몸통통
-
-        if seq is None or total is None or payload_b64 is None:
-            raise PacketFormatError("필수 키가 누락되었다.")
-        if not isinstance(seq, int) or not isinstance(total, int) or not isinstance(payload_b64, str):
-            raise PacketFormatError("키의 데이터 타입 오류이다.")
-        if total <= 0 or not (0 < seq <= total):
-            raise PacketFormatError("필드 값에 오류가 있다.")
-
-        # 4. Base64 인코딩된 페이로드를 디코딩
-        try:
-            payload = base64.b64decode(payload_b64, validate=True)
-        except (binascii.Error, ValueError) as e:
-            raise PacketFormatError(f"잘못된 Base64 페이로드이다: {e}") from e
-
-        # 5. 첫 패킷 수신 시 또는 이후 패킷의 일관성을 확인인
-        if self._expected_total is None:
-            # 첫 번째 패킷이라면 총 패킷 수를 설정하고 내부 저장소를 초기
-            self._expected_total = total
-            self._packets.clear()
-
-        elif total != self._expected_total:
-            # 총 패킷 수가 불일치하면 내부 상태를 초기화한 후 예외를 발생
-            self._reset_state()
-            raise InconsistentPacketDataError("총 패킷 수가 불일치한다.")
-        
-        # 6. 중복된 패킷의 수신 여부를 확인
-        if seq in self._packets:
-            raise DuplicatePacketError(f"중복된 패킷 {seq}이(가) 수신되었다.")
-
-        # 7. 검증된 패킷 데이터를 내부 저장소에 저장
-        self._packets[seq] = payload
-        print(f"[Reassembler] 패킷 저장: {seq}/{self._expected_total} (현재 수신된 패킷: {len(self._packets)}개)이다.")
-
-        # 8. 모든 패킷이 수신되었는지 확인한 후 재조립을 시도
-        if len(self._packets) == self._expected_total:
-
-            # 모든 순번이 제대로 수신되었는지 추가 확인한다.
-            if set(self._packets.keys()) != set(range(1, self._expected_total + 1)):
-                self._reset_state()
-                raise PacketReassemblyError("누락된 패킷이 존재한다.")
-        
-            # 9. 순번에 따라 정렬된 페이로드들을 연결하여 완전한 메시지를 생성한다.
-            try:
-                reassembled = b"".join(self._packets[k] for k in sorted(self._packets))
-            except Exception as e:
-                self._reset_state()
-                raise PacketReassemblyError(f"병합에 실패하였다: {e}") from e
-
-            # 10. 메시지 재조립 완료 후 내부 상태를 초기화하고 완성된 메시지를 반환
-            self._reset_state()
-            return reassembled
-
-        # 11. 모든 패킷이 수신되지 않은 경우 None을 반환
+        # 모두 모였는가?
+        if len(self._pkt) == self._total:
+            if set(self._pkt) != set(range(1, self._total + 1)):
+                self.reset()
+                raise MissingPacketError("패킷 누락")
+            data = b"".join(self._pkt[i] for i in range(1, self._total + 1))
+            self.reset()
+            return data
         return None
-
-    def get_status(self) -> str:
-        # 현재 재조립 상태를 문자열로 반환
-        if self._expected_total is None:
-            return "대기 중이다: 메시지의 첫 패킷을 기다린다."
-        return f"재조립 중이다: {len(self._packets)}/{self._expected_total} 패킷이 수신되었다."
-
-    def reset(self):
-        # 외부에서 호출 가능한 상태 리셋 메서두두
-        self._reset_state()
-        print("[Reassembler] 초기화 완료이다.")

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -1,138 +1,197 @@
+# receiver.py
 # -*- coding: utf-8 -*-
 """
-receiver.py — LoRa 리시버 (한 번만 ACK → 연속 프레임 수신)
+LoRa 리시버
+1) 프로그램 시작 시 SYN 한 줄(readline) 기다림 → ACK 한 번 보냄
+2) 그 뒤 LEN-SEQ-TOTAL-PAYLOAD 스트림을 끊김 없이 처리
 """
 from __future__ import annotations
-import os, time, json, datetime, statistics, serial
+import os, time, json, datetime, statistics, serial # json, datetime 추가 확인
 from collections import deque
 
-from packet_reassembler import PacketReassembler, PacketReassemblyError
-import decoder
+# packet_reassembler.py와 decoder.py가 같은 디렉토리에 있다고 가정
+try:
+    from packet_reassembler import PacketReassembler, PacketReassemblyError
+    import decoder
+except ImportError as e:
+    print(f"모듈 임포트 실패: {e}. packet_reassembler.py와 decoder.py가 올바른 위치에 있는지 확인하세요.")
+    exit(1)
+
 
 # ────────── 설정 ──────────
-PORT          = "/dev/serial0"
-BAUD          = 9600
-HANDSHAKE_TO  = 2.0      # SYN 대기 최대
-READ_TO       = 0.05     # 이후 읽기 타임아웃
-FRAME_MAX     = 58       # 2B 헤더 + 56B payload
-DATA_DIR      = "data/raw"
+PORT         = "/dev/serial0"
+BAUD         = 9600
+HANDSHAKE_TO = 5.0
+READ_TO      = 0.05
+FRAME_MAX    = 58
+DATA_DIR     = "data/raw"
 os.makedirs(DATA_DIR, exist_ok=True)
 
-SYN = b"SYN\r\n"
-ACK = b"ACK\r\n"
+SYN = b"SYN\n"
+ACK = b"ACK\n"
+
+import logging
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def _log_json(payload: dict, meta: dict):
     fn = datetime.datetime.now().strftime("%Y-%m-%d") + ".jsonl"
     with open(os.path.join(DATA_DIR, fn), "a", encoding="utf-8") as fp:
         fp.write(json.dumps({
-            "ts": datetime.datetime.utcnow()
-                  .isoformat(timespec="milliseconds")+"Z",
+            "ts": datetime.datetime.utcnow().isoformat(timespec="milliseconds")+"Z",
             "data": payload,
             "meta": meta
         }, ensure_ascii=False) + "\n")
 
-
 def receive_loop():
-    ser = serial.Serial(PORT, BAUD, timeout=HANDSHAKE_TO)
-    print(f"[{datetime.datetime.now():%F %T}] Receiver start {PORT}@{BAUD}")
+    try:
+        ser = serial.Serial(PORT, BAUD, timeout=HANDSHAKE_TO)
+        logging.info(f"Receiver start {PORT}@{BAUD}")
+    except serial.SerialException as e:
+        logging.error(f"시리얼 포트 {PORT}를 열 수 없습니다: {e}")
+        return
 
-    # 1) 최초 핸드셰이크 (한 번만)
-    line = ser.readline()
-    if line.strip() == SYN.strip():
-        ser.write(ACK); ser.flush()
-        print("핸드셰이크 OK")
-    else:
-        print("핸드셰이크 실패, 종료"); ser.close(); return
+    # ... (핸드셰이크 로직은 변경 없음) ...
+    handshake_successful = False
+    while not handshake_successful:
+        logging.info(f"SYN 대기 중... (기대: {SYN!r})")
+        line = ser.readline()
+        if not line:
+            logging.debug("SYN 대기 타임아웃, 재시도...")
+            continue
+        logging.info(f"핸드셰이크 데이터 수신: {line!r}")
+        if line == SYN:
+            logging.info(f"SYN 수신 확인. ACK 전송: {ACK!r}")
+            ser.write(ACK)
+            ser.flush()
+            logging.info("핸드셰이크 성공 (SYN 수신, ACK 발신)")
+            handshake_successful = True
+        else:
+            logging.warning(f"핸드셰이크 중 예상치 못한 데이터 수신: {line!r} (기대: {SYN!r})")
+    if not handshake_successful:
+        logging.error("핸드셰이크 최종 실패. 종료합니다.")
+        ser.close()
+        return
 
-    # 2) 계속 프레임 수신
     ser.timeout = READ_TO
     buf = deque()
     reasm = PacketReassembler()
-
     inter_arrival: list[float] = []
     pkt_sizes: list[int] = []
     total_bytes = 0
     first_t = last_t = None
+    received_message_count = 0
 
     try:
         while True:
-            chunk = ser.read(ser.in_waiting or 1)
+            bytes_to_read = ser.in_waiting or 1
+            chunk = ser.read(bytes_to_read)
+
             if chunk:
                 buf.extend(chunk)
+                logging.debug(f"데이터 수신: {chunk!r}, 현재 버퍼: {bytes(buf)!r}")
 
-            # LEN 바이트 기반 파싱
             while len(buf) >= 1:
                 length = buf[0]
-                if length < 3 or length > FRAME_MAX:
+                if length < 3 or length > FRAME_MAX: # LEN + SEQ + TOTAL 최소 3바이트
+                    logging.warning(f"비정상적인 프레임 길이 감지: {length}. 해당 바이트 버림.")
                     buf.popleft()
+                    reasm.reset()
+                    inter_arrival.clear(); pkt_sizes.clear(); total_bytes = 0; first_t = last_t = None
                     continue
-                if len(buf) < 1 + length:
+                if len(buf) < 1 + length: # LEN 바이트 + 실제 프레임 길이
                     break
-                buf.popleft()
-                frame = bytes(buf.popleft() for _ in range(length))
+                
+                buf.popleft() # LEN 바이트 제거
+                frame_bytes = [buf.popleft() for _ in range(length)]
+                frame = bytes(frame_bytes) # SEQ, TOTAL, PAYLOAD 부분
+                logging.debug(f"프레임 추출: LEN={length}, FRAME={frame!r}")
 
-                # 통계
                 now = time.time()
                 if last_t is not None:
-                    inter_arrival.append((now - last_t)*1000)
+                    inter_arrival.append((now - last_t) * 1000)
                 last_t = now
-                pkt_sizes.append(length+1)
-                total_bytes += length+1
+                pkt_sizes.append(length + 1) # LEN 포함한 전체 프레임 크기
+                total_bytes += length + 1
                 if first_t is None:
                     first_t = now
 
-                # 재조립 & 디코딩
                 try:
-                    blob = reasm.process_frame(frame)
+                    blob = reasm.process_frame(frame) # blob은 압축된 전체 메시지
                     if blob is None:
+                        logging.debug("프레임 처리: 아직 전체 패킷 아님")
                         continue
-
+                    
+                    received_message_count += 1
+                    # logging.info(f"--- 메시지 #{received_message_count} 재조립 완료 (압축된 크기: {len(blob)}B) ---")
+                    
+                    # decoder.py를 통해 압축 해제 및 파싱하여 딕셔너리 생성
                     payload = decoder.decompress_data(blob)
+                    
                     if payload is None:
-                        print("[decoder] FAIL")
-                        # 클리어 후 다음 메시지 대기
-                        reasm.reset()
+                        # decoder.py 내부에서 "[decoder] 복원 실패: ..." 로그 출력됨
+                        logging.error(f"[receiver] 메시지 #{received_message_count} 데이터 디코딩 실패 (payload is None)")
+                        reasm.reset(); buf.clear()
+                        inter_arrival.clear(); pkt_sizes.clear(); total_bytes = 0; first_t = last_t = None
                         continue
 
-                    latency = int((now - first_t)*1000)
-                    jitter  = statistics.pstdev(inter_arrival) if len(inter_arrival)>1 else 0.0
+                    # ────────── 수신된 payload 내용 터미널 출력 ──────────
+                    logging.info(f"--- 메시지 #{received_message_count} 수신 데이터 (payload) ---")
+                    
+                    # 방법 1: JSON 형태로 전체 딕셔너리 출력 (들여쓰기 적용)
+                    # logging.info(json.dumps(payload, indent=2, ensure_ascii=False))
+
+                    # 방법 2: 주요 항목을 포맷하여 가독성 있게 출력 (권장)
+                    ts_value = payload.get('ts', 0.0) # 기본값 0.0으로 설정 (float이므로)
+                    ts_human_readable = datetime.datetime.fromtimestamp(ts_value).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+                    
+                    accel = payload.get('accel', {})
+                    gyro = payload.get('gyro', {})
+                    angle = payload.get('angle', {})
+                    gps = payload.get('gps', {})
+
+                    display_message = []
+                    display_message.append(f"  Timestamp: {ts_human_readable} (raw: {ts_value:.3f})") # ts도 소수점 표시
+                    display_message.append(f"  Accel (g): Ax={accel.get('ax', 'N/A'):.3f}, Ay={accel.get('ay', 'N/A'):.3f}, Az={accel.get('az', 'N/A'):.3f}")
+                    display_message.append(f"  Gyro (°/s): Gx={gyro.get('gx', 'N/A'):.1f}, Gy={gyro.get('gy', 'N/A'):.1f}, Gz={gyro.get('gz', 'N/A'):.1f}")
+                    display_message.append(f"  Angle (°): Roll={angle.get('roll', 'N/A'):.1f}, Pitch={angle.get('pitch', 'N/A'):.1f}, Yaw={angle.get('yaw', 'N/A'):.1f}")
+                    display_message.append(f"  GPS (°): Lat={gps.get('lat', 'N/A'):.6f}, Lon={gps.get('lon', 'N/A'):.6f}")
+                    logging.info("\n".join(display_message)) # 각 줄을 개행으로 연결하여 출력
+                    # ─────────────────────────────────────────────────────
+
+                    latency = int((now - first_t) * 1000) if first_t is not None else 0
+                    jitter  = statistics.pstdev(inter_arrival) if len(inter_arrival) > 1 else 0.0
                     meta = {
-                        "bytes": len(blob),
+                        "bytes_compressed": len(blob), # 압축된 데이터의 바이트 크기
                         "latency_ms": latency,
-                        "jitter_ms": round(jitter,2),
-                        "total_bytes": total_bytes,
-                        "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes),2),
-                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes),2),
+                        "jitter_ms": round(jitter, 2),
+                        "total_bytes_frames": total_bytes, # 수신된 프레임(LEN+헤더+페이로드)들의 총합
+                        "avg_frame_size": round(sum(pkt_sizes)/len(pkt_sizes), 2) if pkt_sizes else 0,
                     }
-                    print(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
-                          f"{meta['bytes']}B, lat {latency}ms, jit {meta['jitter_ms']}ms")
+                    logging.info(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
+                                 f"Msg#{received_message_count}: {meta['bytes_compressed']}B compressed, "
+                                 f"lat {latency}ms, jit {meta['jitter_ms']}ms")
                     _log_json(payload, meta)
 
-                    # 다음 메시지를 위해 상태 초기화
-                    buf.clear()
                     reasm.reset()
-                    inter_arrival.clear()
-                    pkt_sizes.clear()
-                    total_bytes = 0
-                    first_t = last_t = None
+                    inter_arrival.clear(); pkt_sizes.clear(); total_bytes = 0; first_t = last_t = None
 
                 except PacketReassemblyError as e:
-                    print(f"[ERR] {e}")
-                    reasm.reset()
-                    buf.clear()
-                    inter_arrival.clear()
-                    pkt_sizes.clear()
-                    total_bytes = 0
-                    first_t = last_t = None
-
-            time.sleep(0.005)
+                    logging.error(f"패킷 재조립 오류: {e}")
+                    reasm.reset(); buf.clear()
+                    inter_arrival.clear(); pkt_sizes.clear(); total_bytes = 0; first_t = last_t = None
+            
+            # time.sleep(0.001)
 
     except KeyboardInterrupt:
-        pass
+        logging.info("사용자에 의해 중단됨.")
+    except Exception as e:
+        logging.error(f"예상치 못한 오류 발생: {e}", exc_info=True)
     finally:
-        ser.close()
-
+        if 'ser' in locals() and ser.is_open:
+            ser.close()
+            logging.info("시리얼 포트 닫힘.")
 
 if __name__ == "__main__":
     receive_loop()

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -1,8 +1,10 @@
+# receiver.py
 # -*- coding: utf-8 -*-
 """
-receiver.py — LoRa 리시버 (LEN-SEQ-TOTAL-PAYLOAD)  
-· SYN/ACK：(CRLF)-라인 단위 → flush →  
-· 이후 LEN 기반 버퍼 파싱
+LoRa 수신기: 
+1) SYN/ACK 핸드셰이크 (매 메시지 시작)
+2) LEN-SEQ-TOTAL-PAYLOAD 프레임 수신·재조립
+3) 메시지 완료 시 즉시 상태 초기화 → 반복
 """
 from __future__ import annotations
 import os, time, json, datetime, statistics, serial
@@ -12,12 +14,12 @@ from packet_reassembler import PacketReassembler, PacketReassemblyError
 import decoder
 
 # ────────── 설정 ──────────
-PORT            = "/dev/serial0"
-BAUD            = 9600
-HANDSHAKE_TO    = 2.0
-READ_TIMEOUT    = 0.05
-FRAME_MAX       = 58
-DATA_DIR        = "data/raw"
+PORT          = "/dev/serial0"
+BAUD          = 9600
+HANDSHAKE_TO  = 2.0      # SYN 대기 최대 시간
+READ_TO       = 0.05     # 바이너리 수신 타임아웃
+FRAME_MAX     = 58       # 2B 헤더 + 56B payload (LEN 바이트 제외)
+DATA_DIR      = "data/raw"
 os.makedirs(DATA_DIR, exist_ok=True)
 
 SYN = b"SYN\r\n"
@@ -37,96 +39,108 @@ def _log_json(payload: dict, meta: dict):
 
 def receive_loop():
     ser = serial.Serial(PORT, BAUD, timeout=HANDSHAKE_TO)
-    reasm = PacketReassembler()
-    buf = deque()
-
-    inter = []
-    pkt_sizes = []
-    total_bytes = 0
-    first_t = last_t = None
-
     print(f"[{datetime.datetime.now():%F %T}] Receiver start {PORT}@{BAUD}")
 
-    # 1) SYN/ACK 핸드셰이크 (CRLF 라인 단위)
     while True:
-        line = ser.readline()
-        if line == SYN:
-            ser.write(ACK); ser.flush()
-            break
+        # ─── 1) 핸드셰이크 ───
+        # 매 메시지마다 SYN을 기다리고 ACK를 보냄
+        print("Waiting for SYN…")
+        while True:
+            line = ser.readline()
+            if line == SYN:
+                ser.write(ACK); ser.flush()
+                print("Handshake OK")
+                break
 
-    # 2) 데이터 수신 (LEN-파서)
-    ser.timeout = READ_TIMEOUT
-    try:
+        # ─── 2) 메시지 수신 준비 ───
+        ser.timeout = READ_TO
+        buf = deque()
+        reasm = PacketReassembler()
+        inter_arrival: list[float] = []
+        pkt_sizes: list[int] = []
+        total_bytes = 0
+        first_t = last_t = None
+
+        # ─── 3) 프레임 수신 & 재조립 ───
         while True:
             chunk = ser.read(ser.in_waiting or 1)
             if chunk:
                 buf.extend(chunk)
 
-            # LEN 기반 프레임 파싱
+            # LEN-바이트 기반 파싱
             while len(buf) >= 1:
                 length = buf[0]
+                # 길이 검사
                 if length < 3 or length > FRAME_MAX:
                     buf.popleft()
                     continue
                 if len(buf) < 1 + length:
                     break
-                buf.popleft()
+                buf.popleft()  # LEN 제거
                 frame = bytes(buf.popleft() for _ in range(length))
 
+                # 통계 업데이트
                 now = time.time()
                 if last_t is not None:
-                    inter.append((now - last_t)*1000)
+                    inter_arrival.append((now - last_t) * 1000)
                 last_t = now
-                pkt_sizes.append(length+1)
-                total_bytes += length+1
+                pkt_sizes.append(length + 1)
+                total_bytes += length + 1
+                if first_t is None:
+                    first_t = now
 
+                # 재조립 시도
                 try:
                     blob = reasm.process_frame(frame)
                     if blob is None:
-                        continue
+                        continue  # 아직 모든 패킷이 모이지 않음
 
+                    # 압축 해제 & dict 복원
                     payload = decoder.decompress_data(blob)
                     if payload is None:
                         print("[decoder] FAIL")
-                        continue
+                        # 재조립기는 이미 초기화됐으니 다음 메시지로
+                        break
 
-                    latency = int((now - first_t)*1000) if first_t else 0
-                    jitter  = statistics.pstdev(inter) if len(inter)>1 else 0.0
+                    # 메타 계산
+                    latency = int((now - first_t) * 1000)
+                    jitter  = statistics.pstdev(inter_arrival) if len(inter_arrival) > 1 else 0.0
                     meta = {
                         "bytes": len(blob),
                         "latency_ms": latency,
-                        "jitter_ms": round(jitter,2),
+                        "jitter_ms": round(jitter, 2),
                         "total_bytes": total_bytes,
-                        "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes),2),
-                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes),2),
+                        "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes), 2),
+                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes), 2),
                     }
-                    print(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
-                          f"{meta['bytes']}B, lat {latency} ms, jit {meta['jitter_ms']} ms")
-                    _log_json(payload, meta)
 
-                    # reset for next message
+                    print(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
+                          f"{meta['bytes']}B, lat {latency}ms, jit {meta['jitter_ms']}ms")
+
+                    _log_json(payload, meta)
+                    # 메시지 완료 → 잔여 버퍼·상태 클리어
                     buf.clear()
-                    inter.clear(); pkt_sizes.clear()
-                    total_bytes = 0
-                    first_t = last_t = None
+                    break  # 이 메시지를 끝내고 핸드셰이크 단계로 복귀
 
                 except PacketReassemblyError as e:
                     print(f"[ERR] {e}")
                     reasm.reset()
                     buf.clear()
-                    inter.clear(); pkt_sizes.clear()
+                    # 통계도 리셋
+                    inter_arrival.clear()
+                    pkt_sizes.clear()
                     total_bytes = 0
                     first_t = last_t = None
+                    break  # 재시작
 
-                if first_t is None:
-                    first_t = now
+            # 한 메시지가 끝나면 break to handshake
+            if first_t is not None and reasm._total is None:
+                # reasm._total는 process_frame이 반환 시 reset됨
+                break
 
-            time.sleep(0.01)
+            time.sleep(0.005)
 
-    except KeyboardInterrupt:
-        pass
-    finally:
-        ser.close()
+    # (종료 시리얼 닫기 생략)
 
 
 if __name__ == "__main__":

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -1,10 +1,6 @@
-# receiver.py
 # -*- coding: utf-8 -*-
 """
-LoRa 수신기: 
-1) SYN/ACK 핸드셰이크 (매 메시지 시작)
-2) LEN-SEQ-TOTAL-PAYLOAD 프레임 수신·재조립
-3) 메시지 완료 시 즉시 상태 초기화 → 반복
+receiver.py — LoRa 리시버 (한 번만 ACK → 연속 프레임 수신)
 """
 from __future__ import annotations
 import os, time, json, datetime, statistics, serial
@@ -16,9 +12,9 @@ import decoder
 # ────────── 설정 ──────────
 PORT          = "/dev/serial0"
 BAUD          = 9600
-HANDSHAKE_TO  = 2.0      # SYN 대기 최대 시간
-READ_TO       = 0.05     # 바이너리 수신 타임아웃
-FRAME_MAX     = 58       # 2B 헤더 + 56B payload (LEN 바이트 제외)
+HANDSHAKE_TO  = 2.0      # SYN 대기 최대
+READ_TO       = 0.05     # 이후 읽기 타임아웃
+FRAME_MAX     = 58       # 2B 헤더 + 56B payload
 DATA_DIR      = "data/raw"
 os.makedirs(DATA_DIR, exist_ok=True)
 
@@ -41,106 +37,101 @@ def receive_loop():
     ser = serial.Serial(PORT, BAUD, timeout=HANDSHAKE_TO)
     print(f"[{datetime.datetime.now():%F %T}] Receiver start {PORT}@{BAUD}")
 
-    while True:
-        # ─── 1) 핸드셰이크 ───
-        # 매 메시지마다 SYN을 기다리고 ACK를 보냄
-        print("Waiting for SYN…")
-        while True:
-            line = ser.readline()
-            if line == SYN:
-                ser.write(ACK); ser.flush()
-                print("Handshake OK")
-                break
+    # 1) 최초 핸드셰이크 (한 번만)
+    line = ser.readline()
+    if line.strip() == SYN.strip():
+        ser.write(ACK); ser.flush()
+        print("핸드셰이크 OK")
+    else:
+        print("핸드셰이크 실패, 종료"); ser.close(); return
 
-        # ─── 2) 메시지 수신 준비 ───
-        ser.timeout = READ_TO
-        buf = deque()
-        reasm = PacketReassembler()
-        inter_arrival: list[float] = []
-        pkt_sizes: list[int] = []
-        total_bytes = 0
-        first_t = last_t = None
+    # 2) 계속 프레임 수신
+    ser.timeout = READ_TO
+    buf = deque()
+    reasm = PacketReassembler()
 
-        # ─── 3) 프레임 수신 & 재조립 ───
+    inter_arrival: list[float] = []
+    pkt_sizes: list[int] = []
+    total_bytes = 0
+    first_t = last_t = None
+
+    try:
         while True:
             chunk = ser.read(ser.in_waiting or 1)
             if chunk:
                 buf.extend(chunk)
 
-            # LEN-바이트 기반 파싱
+            # LEN 바이트 기반 파싱
             while len(buf) >= 1:
                 length = buf[0]
-                # 길이 검사
                 if length < 3 or length > FRAME_MAX:
                     buf.popleft()
                     continue
                 if len(buf) < 1 + length:
                     break
-                buf.popleft()  # LEN 제거
+                buf.popleft()
                 frame = bytes(buf.popleft() for _ in range(length))
 
-                # 통계 업데이트
+                # 통계
                 now = time.time()
                 if last_t is not None:
-                    inter_arrival.append((now - last_t) * 1000)
+                    inter_arrival.append((now - last_t)*1000)
                 last_t = now
-                pkt_sizes.append(length + 1)
-                total_bytes += length + 1
+                pkt_sizes.append(length+1)
+                total_bytes += length+1
                 if first_t is None:
                     first_t = now
 
-                # 재조립 시도
+                # 재조립 & 디코딩
                 try:
                     blob = reasm.process_frame(frame)
                     if blob is None:
-                        continue  # 아직 모든 패킷이 모이지 않음
+                        continue
 
-                    # 압축 해제 & dict 복원
                     payload = decoder.decompress_data(blob)
                     if payload is None:
                         print("[decoder] FAIL")
-                        # 재조립기는 이미 초기화됐으니 다음 메시지로
-                        break
+                        # 클리어 후 다음 메시지 대기
+                        reasm.reset()
+                        continue
 
-                    # 메타 계산
-                    latency = int((now - first_t) * 1000)
-                    jitter  = statistics.pstdev(inter_arrival) if len(inter_arrival) > 1 else 0.0
+                    latency = int((now - first_t)*1000)
+                    jitter  = statistics.pstdev(inter_arrival) if len(inter_arrival)>1 else 0.0
                     meta = {
                         "bytes": len(blob),
                         "latency_ms": latency,
-                        "jitter_ms": round(jitter, 2),
+                        "jitter_ms": round(jitter,2),
                         "total_bytes": total_bytes,
-                        "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes), 2),
-                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes), 2),
+                        "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes),2),
+                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes),2),
                     }
-
                     print(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
                           f"{meta['bytes']}B, lat {latency}ms, jit {meta['jitter_ms']}ms")
-
                     _log_json(payload, meta)
-                    # 메시지 완료 → 잔여 버퍼·상태 클리어
+
+                    # 다음 메시지를 위해 상태 초기화
                     buf.clear()
-                    break  # 이 메시지를 끝내고 핸드셰이크 단계로 복귀
+                    reasm.reset()
+                    inter_arrival.clear()
+                    pkt_sizes.clear()
+                    total_bytes = 0
+                    first_t = last_t = None
 
                 except PacketReassemblyError as e:
                     print(f"[ERR] {e}")
                     reasm.reset()
                     buf.clear()
-                    # 통계도 리셋
                     inter_arrival.clear()
                     pkt_sizes.clear()
                     total_bytes = 0
                     first_t = last_t = None
-                    break  # 재시작
-
-            # 한 메시지가 끝나면 break to handshake
-            if first_t is not None and reasm._total is None:
-                # reasm._total는 process_frame이 반환 시 reset됨
-                break
 
             time.sleep(0.005)
 
-    # (종료 시리얼 닫기 생략)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        ser.close()
 
 
 if __name__ == "__main__":

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -15,19 +15,21 @@ DEFAULT_TIMEOUT = 1  # 시리얼 읽기 타임아웃 (초)
 def receive_loop(port=SERIAL_PORT, baud=BAUD_RATE, serial_timeout=DEFAULT_TIMEOUT):
     """
     무한 루프를 통해 지속적으로 패킷을 수신하고 처리합니다.
-    Ctrl-C 입력 시 루프를 종료하고 포트를 닫습니다.
+    패킷이 없으면 주기적으로 "대기중.." 메시지를 출력하며, Ctrl-C로 종료합니다.
     """
     reassembler = PacketReassembler()
     ser = serial.Serial(port, baud, timeout=serial_timeout)
     time.sleep(1)  # 포트 안정화
 
-    print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 시작됨 ({port}, {baud} baud)")
-    print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 계속 수신 대기 중... (중단: Ctrl-C)")
+    start_ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    print(f"[{start_ts}] Receiver: 시작됨 ({port}, {baud} baud)")
+    last_print = time.time()  # 대기 메시지 마지막 출력 시각
+    print(f"[{start_ts}] Receiver: 대기중.. (패킷 수신 대기)")
 
     try:
         while True:
-            # 수신 데이터 확인
             if ser.in_waiting > 0:
+                # 패킷이 도착했으므로 상세 처리 로직 실행
                 line_bytes = ser.readline()
                 if not line_bytes:
                     continue
@@ -43,20 +45,17 @@ def receive_loop(port=SERIAL_PORT, baud=BAUD_RATE, serial_timeout=DEFAULT_TIMEOU
                     continue
 
                 ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-
-                # 패킷 재조립
                 try:
                     reassembled = reassembler.process_line(line)
                     if reassembled is not None:
                         print(f"[{ts}] Receiver: 재조립 완료 - {len(reassembled)} bytes")
-
-                        # 압축 해제 및 JSON 파싱
                         sensor_data = decoder.decompress_data(reassembled)
                         if sensor_data is not None:
                             print(f"[{ts}] Receiver: 데이터 복원 성공 → {sensor_data}")
                         else:
                             print(f"[{ts}] Receiver: 데이터 복원 실패 (Decoder)")
-
+                        # 처리 완료 후, 다시 대기 상태 알림 준비
+                        last_print = time.time()
                 except PacketFormatError as pfe:
                     print(f"[{ts}] Receiver: 잘못된 패킷 형식 - {pfe}")
                 except PacketReassemblyError as pre:
@@ -64,7 +63,12 @@ def receive_loop(port=SERIAL_PORT, baud=BAUD_RATE, serial_timeout=DEFAULT_TIMEOU
                 except Exception as e:
                     print(f"[{ts}] Receiver: 처리 중 예외 - {e}")
             else:
-                # 읽을 데이터 없으면 짧게 대기
+                # 패킷 대기 상태: 주기적으로 메시지 출력
+                now = time.time()
+                if now - last_print >= 1.0:
+                    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                    print(f"[{ts}] Receiver: 대기중.. (패킷 수신 대기)")
+                    last_print = now
                 time.sleep(0.01)
     except KeyboardInterrupt:
         print(f"\n[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 사용자에 의해 중단됨.")

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -130,20 +130,17 @@ def receive_loop():
                     payload = decoder.decompress_data(blob)
                     
                     if payload is None:
-                        # decoder.py 내부에서 "[decoder] 복원 실패: ..." 로그 출력됨
+                        
                         logging.error(f"[receiver] 메시지 #{received_message_count} 데이터 디코딩 실패 (payload is None)")
                         reasm.reset(); buf.clear()
                         inter_arrival.clear(); pkt_sizes.clear(); total_bytes = 0; first_t = last_t = None
                         continue
-
-                    # ────────── 수신된 payload 내용 터미널 출력 ──────────
+                    
                     logging.info(f"--- 메시지 #{received_message_count} 수신 데이터 (payload) ---")
                     
-                    # 방법 1: JSON 형태로 전체 딕셔너리 출력 (들여쓰기 적용)
-                    # logging.info(json.dumps(payload, indent=2, ensure_ascii=False))
+               
 
-                    # 방법 2: 주요 항목을 포맷하여 가독성 있게 출력 (권장)
-                    ts_value = payload.get('ts', 0.0) # 기본값 0.0으로 설정 (float이므로)
+                    ts_value = payload.get('ts', 0.0) 
                     ts_human_readable = datetime.datetime.fromtimestamp(ts_value).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
                     
                     accel = payload.get('accel', {})
@@ -158,7 +155,7 @@ def receive_loop():
                     display_message.append(f"  Angle (°): Roll={angle.get('roll', 'N/A'):.1f}, Pitch={angle.get('pitch', 'N/A'):.1f}, Yaw={angle.get('yaw', 'N/A'):.1f}")
                     display_message.append(f"  GPS (°): Lat={gps.get('lat', 'N/A'):.6f}, Lon={gps.get('lon', 'N/A'):.6f}")
                     logging.info("\n".join(display_message)) # 각 줄을 개행으로 연결하여 출력
-                    # ─────────────────────────────────────────────────────
+              
 
                     latency = int((now - first_t) * 1000) if first_t is not None else 0
                     jitter  = statistics.pstdev(inter_arrival) if len(inter_arrival) > 1 else 0.0

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-receiver.py – LEN‑SEQ‑TOTAL‑PAYLOAD 수신
+receiver.py — LoRa 리시버 (LEN-SEQ-TOTAL-PAYLOAD)
+· readline() 핸드셰이크 → LEN 기반 버퍼 파싱
 """
 from __future__ import annotations
 import os, time, json, datetime, statistics, serial
@@ -9,17 +10,18 @@ from collections import deque
 from packet_reassembler import PacketReassembler, PacketReassemblyError
 import decoder
 
-PORT        = "/dev/serial0"
-BAUD        = 9600
-TIMEOUT_RX  = 0.05
+# ────────── 설정 ──────────
+PORT             = "/dev/serial0"
+BAUD             = 9600
+HANDSHAKE_TO     = 2.0     # SYN 기다릴 최대 시간
+READ_TIMEOUT     = 0.05
+FRAME_MAX        = 58      # 2B 헤더 + 56B payload
+DATA_DIR         = "data/raw"
+os.makedirs(DATA_DIR, exist_ok=True)
 
-FRAME_MAX   = 58        # 2B 헤더 + 56B payload
-LEN_MAX     = FRAME_MAX
+SYN = b"SYN\n"
+ACK = b"ACK\n"
 
-SYN   = b"SYN"
-ACK   = b"ACK\n"
-
-DATA_DIR = "data/raw"; os.makedirs(DATA_DIR, exist_ok=True)
 
 def _log_json(payload: dict, meta: dict):
     fn = datetime.datetime.now().strftime("%Y-%m-%d") + ".jsonl"
@@ -31,54 +33,52 @@ def _log_json(payload: dict, meta: dict):
             "meta": meta
         }, ensure_ascii=False) + "\n")
 
+
 def receive_loop():
-    ser   = serial.Serial(PORT, BAUD, timeout=TIMEOUT_RX)
+    ser   = serial.Serial(PORT, BAUD, timeout=HANDSHAKE_TO)
     reasm = PacketReassembler()
+    buf   = deque()
 
-    buf   = deque()                 # 직렬 수신 버퍼
-    pkt_sizes: list[int] = []
     inter: list[float] = []
-
-    first_t = last_t = None
+    pkt_sizes: list[int] = []
     total_bytes = 0
+    first_t = last_t = None
 
     print(f"[{datetime.datetime.now():%F %T}] Receiver start {PORT}@{BAUD}")
 
+    # 1) SYN/ACK 핸드셰이크 (줄 단위)
+    while True:
+        line = ser.readline()
+        if line.strip() == SYN.strip():
+            ser.write(ACK)
+            break
+
+    # 2) 본격 데이터 수신 (바이너리 LEN 파싱)
+    ser.timeout = READ_TIMEOUT
     try:
-        handshake_done = False
         while True:
-            # ── 읽어 들이기 ──
             chunk = ser.read(ser.in_waiting or 1)
             if chunk:
                 buf.extend(chunk)
 
-            # ── 핸드셰이크 처리 ──
-            if not handshake_done:
-                if b"SYN" in bytes(buf):
-                    ser.readline()          # SYN\r\n 소거
-                    ser.write(ACK)
-                    handshake_done = True
-                    buf.clear()
-                continue
-
-            # ── LEN 기반 프레임 파싱 ──
-            while True:
-                if len(buf) < 1:
+            # LEN 기반 프레임 파싱
+            while len(buf) >= 1:
+                length = buf[0]
+                if length < 3 or length > FRAME_MAX:
+                    buf.popleft()
+                    continue
+                if len(buf) < 1 + length:
                     break
-                frame_len = buf[0]
-                if frame_len == 0 or frame_len > LEN_MAX:
-                    buf.popleft(); continue   # 잘못된 LEN, 버림
-                if len(buf) < 1 + frame_len:
-                    break                     # 아직 다 안 옴
-                buf.popleft()                 # LEN 바이트 삭제
-                frame = bytes(buf.popleft() for _ in range(frame_len))
+                buf.popleft()  # LEN 제거
+                frame = bytes(buf.popleft() for _ in range(length))
 
+                # 통계 업데이트
                 now = time.time()
                 if last_t is not None:
                     inter.append((now - last_t) * 1000)
                 last_t = now
-                pkt_sizes.append(frame_len + 1)   # LEN 포함
-                total_bytes += frame_len + 1
+                pkt_sizes.append(length + 1)
+                total_bytes += length + 1
 
                 try:
                     blob = reasm.process_frame(frame)
@@ -87,30 +87,34 @@ def receive_loop():
 
                     payload = decoder.decompress_data(blob)
                     if payload is None:
-                        print("[decoder] FAIL"); continue
+                        print("[decoder] FAIL")
+                        continue
 
-                    jitter = statistics.pstdev(inter) if len(inter) > 1 else 0.0
-                    latency = int((now - first_t)*1000) if first_t else 0
+                    latency = int((now - first_t) * 1000) if first_t else 0
+                    jitter  = statistics.pstdev(inter) if len(inter) > 1 else 0.0
                     meta = {
                         "bytes": len(blob),
                         "latency_ms": latency,
                         "jitter_ms": round(jitter, 2),
                         "total_bytes": total_bytes,
                         "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes), 2),
+                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes), 2),
                     }
                     print(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
-                          f"{meta['bytes']}B, lat {latency}ms, jit {meta['jitter_ms']}ms")
+                          f"{meta['bytes']}B, lat {latency} ms, jit {meta['jitter_ms']} ms")
                     _log_json(payload, meta)
 
-                    # 통계 리셋
-                    pkt_sizes.clear(); inter.clear()
+                    # 새 메시지 통계 초기화
+                    buf.clear()
+                    inter.clear(); pkt_sizes.clear()
                     total_bytes = 0
                     first_t = last_t = None
 
                 except PacketReassemblyError as e:
                     print(f"[ERR] {e}")
                     reasm.reset()
-                    pkt_sizes.clear(); inter.clear()
+                    buf.clear()
+                    inter.clear(); pkt_sizes.clear()
                     total_bytes = 0
                     first_t = last_t = None
 
@@ -123,6 +127,7 @@ def receive_loop():
         pass
     finally:
         ser.close()
+
 
 if __name__ == "__main__":
     receive_loop()

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -1,82 +1,152 @@
-# receiver.py (모듈)
-import serial
-import time
-import datetime
 
-from packet_reassembler import PacketReassembler, PacketFormatError, PacketReassemblyError
-import decoder  # 압축 해제 및 데이터 복원 모듈
+# ------------------------------------------------------------
+# ㆍ패킷 손실률(loss_pct)   ㆍ지연(latency_ms)   ㆍ지터(jitter_ms)
+# ㆍlink_score(0~100)       ㆍ원본 바이트(bytes)
+# ㆍ총 수신 바이트(total_bytes) ㆍ평균 패킷 크기(avg_pkt)
+# ㆍ패킷 크기² 평균(avg_pkt2)
+# ------------------------------------------------------------
+from __future__ import annotations
+import os, time, json, datetime, statistics, serial
+from packet_reassembler import (
+    PacketReassembler, PacketFormatError, PacketReassemblyError
+)
+import decoder
 
-# 시리얼 설정
 SERIAL_PORT = '/dev/serial0'
-BAUD_RATE = 9600
-DEFAULT_TIMEOUT = 1  # 시리얼 읽기 타임아웃 (초)
+BAUD_RATE   = 9600
+TIMEOUT     = 1
+
+SYN_MSG = "SYN"
+ACK_MSG = "ACK"
+
+DATA_DIR = "data/raw"
+os.makedirs(DATA_DIR, exist_ok=True)
 
 
-def receive_loop(port=SERIAL_PORT, baud=BAUD_RATE, serial_timeout=DEFAULT_TIMEOUT):
-    """
-    무한 루프를 통해 지속적으로 패킷을 수신하고 처리합니다.
-    패킷이 없으면 주기적으로 "대기중.." 메시지를 출력하며, Ctrl-C로 종료합니다.
-    """
-    reassembler = PacketReassembler()
-    ser = serial.Serial(port, baud, timeout=serial_timeout)
-    time.sleep(1)  # 포트 안정화
+def _log_json(payload: dict, meta: dict):
+    fn = datetime.datetime.now().strftime("%Y-%m-%d") + ".jsonl"
+    with open(os.path.join(DATA_DIR, fn), "a", encoding="utf-8") as fp:
+        fp.write(json.dumps({
+            "ts": datetime.datetime.utcnow()
+                  .isoformat(timespec="milliseconds")+"Z",
+            "data": payload,
+            "meta": meta
+        }, ensure_ascii=False) + "\n")
 
-    start_ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    print(f"[{start_ts}] Receiver: 시작됨 ({port}, {baud} baud)")
-    last_print = time.time()  # 대기 메시지 마지막 출력 시각
-    print(f"[{start_ts}] Receiver: 대기중.. (패킷 수신 대기)")
+def _link_score(loss_pct: float, latency_ms: int, jitter_ms: float) -> int:
+    """간단 스코어: 100 – 손실(%) – 지연/10 – 지터/10 (0~100)"""
+    score = 100 - loss_pct - latency_ms/10 - jitter_ms/10
+    return int(max(0, min(100, score)))
+
+def receive_loop():
+    ser   = serial.Serial(SERIAL_PORT, BAUD_RATE, timeout=TIMEOUT)
+    reasm = PacketReassembler()
+
+    cur_id: int | None = None
+    expect = recv = 0
+    first_t: float | None = None
+
+    pkt_sizes: list[int] = []
+    inter_arrival: list[float] = []
+    last_pkt_time: float | None = None
+    total_bytes = 0
+
+    print(f"[{datetime.datetime.now():%F %T}] Receiver start {SERIAL_PORT}@{BAUD_RATE}")
 
     try:
+        last_print = time.time()
         while True:
-            if ser.in_waiting > 0:
-                # 패킷이 도착했으므로 상세 처리 로직 실행
-                line_bytes = ser.readline()
-                if not line_bytes:
+            if ser.in_waiting:
+                raw = ser.readline()
+                if not raw:
                     continue
-
-                # UTF-8 디코딩
                 try:
-                    line = line_bytes.decode('utf-8', errors='ignore').strip()
+                    line = raw.decode('utf-8', errors='ignore').strip()
                     if not line:
                         continue
-                except UnicodeDecodeError as ude:
-                    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-                    print(f"[{ts}] Receiver: 디코딩 실패 - {ude}")
+                except UnicodeDecodeError:
                     continue
 
-                ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+                # SYN 핸드셰이크
+                if line == SYN_MSG:
+                    ser.write((ACK_MSG + "\n").encode())
+                    last_print = time.time()
+                    continue
+
+                # 첫 패킷 → 메시지 메타 초기화
                 try:
-                    reassembled = reassembler.process_line(line)
-                    if reassembled is not None:
-                        print(f"[{ts}] Receiver: 재조립 완료 - {len(reassembled)} bytes")
-                        sensor_data = decoder.decompress_data(reassembled)
-                        if sensor_data is not None:
-                            print(f"[{ts}] Receiver: 데이터 복원 성공 → {sensor_data}")
-                        else:
-                            print(f"[{ts}] Receiver: 데이터 복원 실패 (Decoder)")
-                        # 처리 완료 후, 다시 대기 상태 알림 준비
-                        last_print = time.time()
-                except PacketFormatError as pfe:
-                    print(f"[{ts}] Receiver: 잘못된 패킷 형식 - {pfe}")
-                except PacketReassemblyError as pre:
-                    print(f"[{ts}] Receiver: 재조립 오류 - {pre}")
-                except Exception as e:
-                    print(f"[{ts}] Receiver: 처리 중 예외 - {e}")
-            else:
-                # 패킷 대기 상태: 주기적으로 메시지 출력
+                    hdr = json.loads(line)
+                    if isinstance(hdr, dict) and hdr.get("seq") == 1:
+                        cur_id  = hdr.get("id")
+                        expect  = hdr.get("total", 0)
+                        recv    = 0
+                        first_t = time.time()
+                        pkt_sizes.clear()
+                        inter_arrival.clear()
+                        total_bytes = 0
+                        last_pkt_time = None
+                except json.JSONDecodeError:
+                    pass
+
+                # 인터벌·패킷 크기 기록
                 now = time.time()
-                if now - last_print >= 1.0:
-                    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-                    print(f"[{ts}] Receiver: 대기중.. (패킷 수신 대기)")
-                    last_print = now
+                if last_pkt_time is not None:
+                    inter_arrival.append((now - last_pkt_time)*1000)  # ms
+                last_pkt_time = now
+                pkt_sizes.append(len(line))
+                total_bytes += len(line)
+                recv += 1
+
+                ts = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+                try:
+                    assembled = reasm.process_line(line)
+                    if assembled is None:
+                        continue
+
+                    latency_ms = int((time.time() - first_t)*1000) if first_t else 0
+                    loss_pct   = (expect - recv) / expect * 100 if expect else 0
+                    jitter_ms  = statistics.pstdev(inter_arrival) if len(inter_arrival) > 1 else 0.0
+                    meta = {
+                        "bytes": len(assembled),
+                        "pkts_expected": expect,
+                        "pkts_recv": recv,
+                        "missing": max(expect - recv, 0),
+                        "latency_ms": latency_ms,
+                        "loss_pct": round(loss_pct, 2),
+                        "jitter_ms": round(jitter_ms, 2),
+                        "link_score": _link_score(loss_pct, latency_ms, jitter_ms),
+                        "total_bytes": total_bytes,
+                        "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes), 2),
+                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes), 2)
+                    }
+                   
+
+                    payload = decoder.decompress_data(assembled)
+                    if payload:
+                        print(f"[{ts}] OK score={meta['link_score']} "
+                              f"loss={meta['loss_pct']:.1f}% "
+                              f"lat={latency_ms}ms jit={meta['jitter_ms']:.1f}ms")
+                        _log_json(payload, meta)
+                        ser.write(f"ACK:{cur_id}\n".encode())
+                    else:
+                        print(f"[{ts}] Decoder FAIL")
+                        ser.write(f"NAK:{cur_id}\n".encode())
+                    last_print = time.time()
+
+                except (PacketFormatError, PacketReassemblyError) as e:
+                    print(f"[{ts}] ERR – {e}")
+                    ser.write(f"NAK:{cur_id}\n".encode())
+
+            else:
+                if time.time() - last_print > 5:
+                    print(f"[{datetime.datetime.now():%F %T}] waiting …")
+                    last_print = time.time()
                 time.sleep(0.01)
+
     except KeyboardInterrupt:
-        print(f"\n[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 사용자에 의해 중단됨.")
+        pass
     finally:
-        if ser and ser.is_open:
-            ser.close()
-            print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 포트 닫힘")
+        ser.close()
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     receive_loop()

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -7,7 +7,7 @@ from packet_reassembler import PacketReassembler, PacketFormatError, PacketReass
 import decoder  # 압축 해제 및 데이터 복원 모듈
 
 # 시리얼 설정
-SERIAL_PORT = '/dev/ttyS0'
+SERIAL_PORT = '/dev/serial0'
 BAUD_RATE = 9600
 DEFAULT_TIMEOUT = 1  # 시리얼 읽기 타임아웃 (초)
 

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -2,149 +2,77 @@
 import serial
 import time
 import datetime
-# PacketReassembler 클래스와 예외 클래스를 임포트한다고 가정
-from packet_reassembler import PacketReassembler, PacketFormatError, PacketReassemblyError
-import decoder            # 사용자 정의 모듈: 압축 해제 및 데이터 복원 기능 수행
 
-# 모듈 레벨 상수 (외부에서 변경 가능하게 하려면 다른 방식 고려)
+from packet_reassembler import PacketReassembler, PacketFormatError, PacketReassemblyError
+import decoder  # 압축 해제 및 데이터 복원 모듈
+
+# 시리얼 설정
 SERIAL_PORT = '/dev/ttyS0'
 BAUD_RATE = 9600
-DEFAULT_TIMEOUT = 1 # 시리얼 읽기 타임아웃 기본값
+DEFAULT_TIMEOUT = 1  # 시리얼 읽기 타임아웃 (초)
 
-# --- 핵심 수신 및 처리 함수 ---
+
 def receive_loop(port=SERIAL_PORT, baud=BAUD_RATE, serial_timeout=DEFAULT_TIMEOUT):
     """
-
-    Args:
-        port (str): 사용할 시리얼 포트 경로.
-        baud (int): 통신 속도 (Baud rate).
-        serial_timeout (int/float): 시리얼 포트 읽기 타임아웃 (초).
-
-    Returns:
-        object: 성공적으로 복원된 센서 데이터 객체.
-        None: 메시지 수신/처리 실패 또는 타임아웃 발생 시.
-               (KeyboardInterrupt 등 외부 요인 제외)
-    
-    receiver -> ressembler -> receiver -> decoder
-
+    무한 루프를 통해 지속적으로 패킷을 수신하고 처리합니다.
+    Ctrl-C 입력 시 루프를 종료하고 포트를 닫습니다.
     """
-    start_time = time.time()
-    reassembler = PacketReassembler() 
-    final_sensor_data = None
+    reassembler = PacketReassembler()
+    ser = serial.Serial(port, baud, timeout=serial_timeout)
+    time.sleep(1)  # 포트 안정화
 
-    # 이 함수가 호출될 때마다 로그 출력 (모듈 사용자에게 정보 제공)
     print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 시작됨 ({port}, {baud} baud)")
-    print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 데이터 수신 대기 중...")
+    print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 계속 수신 대기 중... (중단: Ctrl-C)")
 
-    ser = None
     try:
-        ser = serial.Serial(port, baud, timeout=serial_timeout)
-        time.sleep(1) # 포트 안정화 대기
+        while True:
+            # 수신 데이터 확인
+            if ser.in_waiting > 0:
+                line_bytes = ser.readline()
+                if not line_bytes:
+                    continue
 
-        # TODO: 무한정 대기 대신 타임아웃 로직 추가 고려
-        # 예를 들어, 전체 메시지 수신에 대한 타임아웃 설정 가능
-        # message_timeout = 30 # 초
-        # message_start_time = time.time()
-
-        while True: 
-
-            try:
-                if ser.in_waiting > 0:
-                    line_bytes = ser.readline()
-                    if not line_bytes: # 타임아웃 또는 빈 데이터
-                        # 타임아웃이 자주 발생하면 문제일 수 있으므로, 필요시 로깅 또는 처리 추가
+                # UTF-8 디코딩
+                try:
+                    line = line_bytes.decode('utf-8', errors='ignore').strip()
+                    if not line:
                         continue
+                except UnicodeDecodeError as ude:
+                    ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+                    print(f"[{ts}] Receiver: 디코딩 실패 - {ude}")
+                    continue
 
-                    try:
-                        line = line_bytes.decode('utf-8', errors='ignore').strip() 
-                        if not line:
-                            continue
+                ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
 
-                    except UnicodeDecodeError as ude:
-                        timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-                        print(f"[{timestamp}] Receiver: 오류 - 데이터 디코딩 실패 - {ude}")
-                        continue
+                # 패킷 재조립
+                try:
+                    reassembled = reassembler.process_line(line)
+                    if reassembled is not None:
+                        print(f"[{ts}] Receiver: 재조립 완료 - {len(reassembled)} bytes")
 
-                    timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+                        # 압축 해제 및 JSON 파싱
+                        sensor_data = decoder.decompress_data(reassembled)
+                        if sensor_data is not None:
+                            print(f"[{ts}] Receiver: 데이터 복원 성공 → {sensor_data}")
+                        else:
+                            print(f"[{ts}] Receiver: 데이터 복원 실패 (Decoder)")
 
-                    try:
-
-                        # packet_ressembler.py 
-                        reassembled_data = reassembler.process_line(line) 
-
-                        if reassembled_data is not None: ## 재조립된 데이터가 있는 경우
-
-
-                            print(f"[{timestamp}] Receiver: 재조립 완료 (Reassembler) - {len(reassembled_data)} bytes")
-                            print("[DEBUG] header bytes:", reassembled_data[:2].hex())
-                            
-                            # decoder.py
-                            sensor_data = decoder.decompress_data(reassembled_data)
-
-                            if sensor_data is None:
-                                print(f"[{timestamp}] Receiver: 오류 - 데이터 복원 실패 (Decoder)")
-                            else:
-                                print(f"[{timestamp}] Receiver: 압축 해제 완료 (Decoder) - 센서 데이터 복원됨.")
-                                final_sensor_data = sensor_data
-
-
-                            # 메시지 처리 완료, 루프 및 함수 종료
-                            return final_sensor_data
-
-                    except PacketFormatError as pfe:
-                        print(f"[{timestamp}] Receiver: 오류 - 잘못된 패킷 형식 - {pfe}")
-                        
-                    except PacketReassemblyError as pre:
-                        print(f"[{timestamp}] Receiver: 오류 - 재조립 중 문제 - {pre}")
-
-                    except Exception as process_err:
-                        print(f"[{timestamp}] Receiver: 오류 - 데이터 처리 중 - {process_err}")
-
-                else:
-                    # 읽을 데이터가 없을 때 CPU 사용 방지
-                    time.sleep(0.01)
-
-
-            except Exception as loop_err:
-                # 루프 내 예상치 못한 오류 (예: Reassembler 내부 오류 등)
-                print(f"\n[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 오류 - 수신 루프 중 오류 발생: {loop_err}")
-                time.sleep(0.1) # 잠시 대기 후 계속 시도? 또는 루프 종료 결정 필요
-
-    except serial.SerialException as e:
-        print(f"\n[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 시리얼 오류 - 포트({port}) 문제: {e}")
-        return None # 시리얼 오류 시 None 반환
+                except PacketFormatError as pfe:
+                    print(f"[{ts}] Receiver: 잘못된 패킷 형식 - {pfe}")
+                except PacketReassemblyError as pre:
+                    print(f"[{ts}] Receiver: 재조립 오류 - {pre}")
+                except Exception as e:
+                    print(f"[{ts}] Receiver: 처리 중 예외 - {e}")
+            else:
+                # 읽을 데이터 없으면 짧게 대기
+                time.sleep(0.01)
     except KeyboardInterrupt:
         print(f"\n[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 사용자에 의해 중단됨.")
-        # KeyboardInterrupt는 호출한 쪽으로 전파되도록 re-raise 하거나 None 반환
-        raise # 또는 return None
-    except Exception as e:
-        print(f"\n[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 예상치 못한 오류 발생: {e}")
-        return None # 그 외 오류 시 None 반환
     finally:
         if ser and ser.is_open:
             ser.close()
-            print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 시리얼 포트 닫힘.")
+            print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 포트 닫힘")
 
-        elapsed_time = time.time() - start_time
-        status = "성공" if final_sensor_data else "실패 또는 중단"
-        print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Receiver: 종료됨 (상태: {status}, 소요시간: {elapsed_time:.2f} 초)")
-        # 최종 데이터는 return 문에서 반환됨
 
- 
-if __name__ == "__main__":
-    print("="*30)
-    print(" Receiver Module - Direct Test ")
-    print("="*30)
-    print(f"테스트: 시리얼 포트 {SERIAL_PORT}에서 메시지 수신 시도...")
-
-    # 테스트 목적으로 함수 직접 호출
-    result_data = receive_loop(port=SERIAL_PORT, baud=BAUD_RATE)
-
-    if result_data:
-        print("\n[테스트 결과] 데이터 수신 및 복원 성공:")
-        # 실제 데이터 형태에 맞게 출력
-        print(result_data)
-    else:
-        print("\n[테스트 결과] 데이터 수신 또는 복원에 실패했습니다.")
-
-    print("\nReceiver Module 테스트 종료.") 
+if __name__ == '__main__':
+    receive_loop()

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -40,11 +40,12 @@ def receive_loop():
     try:
         while True:
             # ─── SYN/ACK (ASCII) ───
-            if ser.in_waiting and ser.peek(1)[:1] == b'S':
-                line = ser.readline()
-                if line.strip() == b"SYN":
+            if ser.in_waiting and ser.read(1) == b'S':
+                line = ser.readline()           # 나머지 읽어서 SYN\r\n 확인
+                if (b'S' + line).strip() == b"SYN":
                     ser.write(ACK_MSG)
                 continue
+
 
             # ─── 바이너리 프레임 ───
             if ser.in_waiting:

--- a/source/receiver/receiver.py
+++ b/source/receiver/receiver.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
+"""
+receiver.py – 2 B 헤더 + payload 프레임 수신
+· 프레임은 LF('\n')로 구분됨
+"""
 from __future__ import annotations
 import os, time, json, datetime, statistics, serial
-
 from packet_reassembler import PacketReassembler, PacketReassemblyError
 import decoder
 
-PORT       = "/dev/serial0"
-BAUD       = 9600
-TIMEOUT_RX = 0.1           # 짧은 바이너리 프레임용
-FRAME_MAX  = 58            # 2B 헤더 + 56B payload
+PORT        = "/dev/serial0"
+BAUD        = 9600
+TIMEOUT_RX  = 0.1
+FRAME_MAX   = 58               # 2B 헤더 + 56B payload
 
-SYN_MSG = b"SYN\r\n"
-ACK_MSG = b"ACK\n"
+SYN   = b"SYN"
+ACK   = b"ACK\n"
 
 DATA_DIR = "data/raw"; os.makedirs(DATA_DIR, exist_ok=True)
 
@@ -29,77 +32,72 @@ def receive_loop():
     ser   = serial.Serial(PORT, BAUD, timeout=TIMEOUT_RX)
     reasm = PacketReassembler()
 
-    expect = recv = 0
-    inter  : list[float] = []
-    last_t = first_t = None
-    total_bytes = 0
+    inter: list[float] = []
     pkt_sizes: list[int] = []
+    total_bytes = 0
+    first_t = last_t = None
 
     print(f"[{datetime.datetime.now():%F %T}] Receiver start {PORT}@{BAUD}")
 
     try:
         while True:
-            # ─── SYN/ACK (ASCII) ───
-            if ser.in_waiting and ser.read(1) == b'S':
-                line = ser.readline()           # 나머지 읽어서 SYN\r\n 확인
-                if (b'S' + line).strip() == b"SYN":
-                    ser.write(ACK_MSG)
+            raw = ser.readline()              # LF 기준
+            if not raw:
+                time.sleep(0.01); continue
+
+            # ── SYN/ACK ──
+            if raw.strip() == SYN:
+                ser.write(ACK)
                 continue
 
+            frame = raw.rstrip(b"\r\n")       # LF 제거
+            if len(frame) < 3 or len(frame) > FRAME_MAX:
+                continue                      # 길이 오류
 
-            # ─── 바이너리 프레임 ───
-            if ser.in_waiting:
-                frame = ser.read(ser.in_waiting)   # LoRa 모듈은 프레임 단위로 UART 출력
-                if not frame:
-                    continue
-                if len(frame) > FRAME_MAX or len(frame) < 3:
-                    continue                       # 잘못된 길이
+            now = time.time()
+            if last_t is not None:
+                inter.append((now - last_t) * 1000)  # ms
+            last_t = now
+            pkt_sizes.append(len(frame))
+            total_bytes += len(frame)
 
-                # 통계용
-                now = time.time()
-                if last_t is not None:
-                    inter.append((now - last_t) * 1000)
-                last_t = now
-                pkt_sizes.append(len(frame))
-                total_bytes += len(frame)
+            try:
+                blob = reasm.process_frame(frame)
+                if blob is None:
+                    continue  # 아직 미완
 
-                try:
-                    data_blob = reasm.process_frame(frame)
-                    if data_blob is None:
-                        continue  # 아직 다 안 모임
+                payload = decoder.decompress_data(blob)
+                if payload is None:
+                    print("[decoder] FAIL"); continue
 
-                    # ─── 복원 성공 ───
-                    payload = decoder.decompress_data(data_blob)
-                    if payload is None:
-                        print("[decoder] FAIL"); continue
+                jitter   = statistics.pstdev(inter) if len(inter) > 1 else 0.0
+                latency  = int((now - first_t)*1000) if first_t else 0
+                meta = {
+                    "bytes": len(blob),
+                    "latency_ms": latency,
+                    "jitter_ms": round(jitter, 2),
+                    "total_bytes": total_bytes,
+                    "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes), 2),
+                    "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes), 2),
+                }
+                print(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
+                      f"{meta['bytes']}B, lat {latency} ms, jit {meta['jitter_ms']} ms")
+                _log_json(payload, meta)
 
-                    loss_pct = (reasm._total - recv) / reasm._total * 100 if reasm._total else 0
-                    meta = {
-                        "bytes": len(data_blob),
-                        "latency_ms": int((now - first_t)*1000) if first_t else 0,
-                        "loss_pct": round(loss_pct, 2),
-                        "jitter_ms": round(statistics.pstdev(inter), 2) if len(inter) > 1 else 0,
-                        "total_bytes": total_bytes,
-                        "avg_pkt": round(sum(pkt_sizes)/len(pkt_sizes), 2),
-                        "avg_pkt2": round(sum(x*x for x in pkt_sizes)/len(pkt_sizes), 2),
-                    }
-                    print(f"[{datetime.datetime.now():%H:%M:%S.%f} OK] "
-                          f"{meta['bytes']}B, loss {meta['loss_pct']}%, "
-                          f"lat {meta['latency_ms']} ms")
-                    _log_json(payload, meta)
+                # 새 메시지 통계 초기화
+                inter.clear(); pkt_sizes.clear()
+                total_bytes = 0
+                first_t = last_t = None
 
-                    # 새 메시지 통계 초기화
-                    expect = recv = 0
-                    inter.clear(); pkt_sizes.clear()
-                    first_t = last_t = None
-                    total_bytes = 0
+            except PacketReassemblyError as e:
+                print(f"[ERR] {e}")
+                reasm.reset()
+                inter.clear(); pkt_sizes.clear()
+                total_bytes = 0
+                first_t = last_t = None
 
-                except PacketReassemblyError as e:
-                    print(f"[ERR] {e}")
-                    reasm.reset()
-
-            else:
-                time.sleep(0.01)
+            if first_t is None:
+                first_t = now
 
     except KeyboardInterrupt:
         pass

--- a/source/transmitter/e22_config.py
+++ b/source/transmitter/e22_config.py
@@ -8,9 +8,7 @@ WRITE_TIMEOUT  = 2    # 초
 READ_TIMEOUT   = 1    # 초
 
 def init_serial() -> serial.Serial:
-    """
-    E22 모듈용 시리얼 포트를 열고 반환합니다.
-    """
+
     return serial.Serial(
         port=SERIAL_PORT,
         baudrate=BAUD_RATE,

--- a/source/transmitter/encoder.py
+++ b/source/transmitter/encoder.py
@@ -8,21 +8,21 @@ from __future__ import annotations
 import struct, zlib, math
 from typing import Dict, Any, List
 
-# ────────── 직렬화 ──────────
-_FMT = "<Ihhhhhhhhhff"            # 4+18+8 = 30 B → zlib 압축 후 18~22 B
+
+_FMT = "<Ihhhhhhhhhff"            
 _FIELDS = (
-    ("ts",        1),             # uint32  (s)
-    ("accel.ax",  1000),          # int16   (0.001 g)
-    ("accel.ay",  1000),
-    ("accel.az",  1000),
-    ("gyro.gx",   10),            # int16   (0.1 °/s)
-    ("gyro.gy",   10),
-    ("gyro.gz",   10),
-    ("angle.roll", 10),           # int16   (0.1 °)
-    ("angle.pitch",10),
-    ("angle.yaw", 10),
-    ("gps.lat",   1.0),           # float32 (°)
-    ("gps.lon",   1.0),
+    ("ts",        1),             #(Unsigned Integer, 4 바이트)
+    ("accel.ax",  1000),          # (Signed Short, 2 바이트)
+    ("accel.ay",  1000),        # (Signed Short, 2 바이트)
+    ("accel.az",  1000),    # (Signed Short, 2 바이트)
+    ("gyro.gx",   10),         # (Signed Short, 2 바이트)
+    ("gyro.gy",   10),        # (Signed Short, 2 바이트)
+    ("gyro.gz",   10),    # (Signed Short, 2 바이트)
+    ("angle.roll", 10),             # (Signed Short, 2 바이트)
+    ("angle.pitch",10),        # (Signed Short, 2 바이트)
+    ("angle.yaw", 10),   # (Signed Short, 2 바이트)
+    ("gps.lat",   1.0),           # (Float, 4 바이트)
+    ("gps.lon",   1.0),          # (Float, 4 바이트)
 )
 
 def _extract(src: Dict[str, Any], dotted: str):

--- a/source/transmitter/packetizer.py
+++ b/source/transmitter/packetizer.py
@@ -1,57 +1,14 @@
-import math
-from typing import List
+# -*- coding: utf-8 -*-
+"""
+packetizer.py
+• encoder.compress_data() 결과를 LoRa 프레임(≤58 B)로 변환만 담당
+"""
+from __future__ import annotations
+from typing import Dict, Any, List
+from encoder import compress_data, split_into_packets, MAX_PAYLOAD
 
-def split_into_packets(data: bytes, max_size: int = 50) -> List[dict]:
-    """
-    바이트 데이터를 LoRa 전송에 적합하도록 max_size 단위로 분할하고
-    각 패킷에 순서 정보와 전체 개수 포함
-    
-    반환 형식:
-    [
-        {"seq": 1, "total": 5, "payload": b"..."},
-        {"seq": 2, "total": 5, "payload": b"..."},
-        ...
-    ]
-    """
-    if max_size <= 0:
-        raise ValueError("max_size는 0보다 커야 합니다.")
-
-    total_packets = math.ceil(len(data) / max_size)
-    packets = []
-
-    for i in range(total_packets):
-        start = i * max_size
-        end = start + max_size
-        payload = data[start:end]
-        packet = {
-            "seq": i + 1,          # seq는 1부터 시작
-            "total": total_packets,
-            "payload": payload     # bytes 형태 그대로 반환
-        }
-
-        if len(payload) > max_size:
-            raise ValueError(f"{i+1}번째 패킷의 payload가 max_size({max_size})를 초과합니다.")
-
-        packets.append(packet)
-
-    return packets
-
-'''# 테스트 코드 (직접 실행 시)
-if __name__ == "__main__":
-    import zlib
-
-    dummy_text = b"The quick brown fox jumps over the lazy dog" * 5
-    compressed = zlib.compress(dummy_text)
-
-    print(f"압축된 데이터 크기: {len(compressed)} bytes")
-
-    split_packets = split_into_packets(compressed, max_size=50)
-
-    for p in split_packets:
-        print({
-            "seq": p["seq"],
-            "total": p["total"],
-            "payload_len": len(p["payload"]),
-            "payload": p["payload"]
-        })
-    '''
+def make_frames(sample: Dict[str, Any]) -> List[bytes]:
+    """센서 dict → zlib 압축 → 2 B 헤더+payload 바이트 시퀀스 반환"""
+    blob   = compress_data(sample)
+    pkts   = split_into_packets(blob, MAX_PAYLOAD)
+    return [bytes([p["seq"], p["total"]]) + p["payload"] for p in pkts]

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,39 +1,52 @@
+# sender.py
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
 import time, logging, serial
 from typing import Any, Dict, List
 
-from e22_config    import init_serial
-from packetizer    import make_frames
-from sensor_reader import SensorReader
+# e22_config, packetizer, sensor_reader는 올바르게 임포트된다고 가정
+try:
+    from e22_config    import init_serial
+    from packetizer    import make_frames
+    from sensor_reader import SensorReader
+except ImportError as e:
+    print(f"모듈 임포트 실패: {e}. 필요한 파일들이 올바른 위치에 있는지 확인하세요.")
+    exit(1)
+
 
 # ────────── 설정 ──────────
 MAX_PAYLOAD       = 56
-FRAME_MAX         = 2 + MAX_PAYLOAD
-HANDSHAKE_TIMEOUT = 2.0
+FRAME_MAX         = 2 + MAX_PAYLOAD # LEN 바이트 제외한 프레임의 최대 길이 (SEQ+TOTAL+PAYLOAD_CHUNK)
+HANDSHAKE_TIMEOUT = 5.0 # 수신기와 유사하게, 또는 약간 더 길게 설정 권장
 SEND_COUNT        = 1000
 RETRY_HANDSHAKE   = 5
 DELAY_BETWEEN     = 0.3
 
-SYN = b"SYN\r\n"
-ACK = b"ACK\r\n"
+# 수신기가 b"SYN\n"을 기대하므로, 여기에 맞춥니다.
+SYN = b"SYN\n"
+ACK = b"ACK\n"
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def _open_serial() -> serial.Serial:
-    s = init_serial()
-    s.timeout = HANDSHAKE_TIMEOUT
-    time.sleep(0.1)
-    return s
+    try:
+        s = init_serial()
+        s.timeout = HANDSHAKE_TIMEOUT # 핸드셰이크용 타임아웃 설정
+        time.sleep(0.1) # 모듈 안정화 시간
+        return s
+    except serial.SerialException as e:
+        logging.error(f"시리얼 포트 열기 실패 (e22_config.init_serial): {e}")
+        raise # 예외를 다시 발생시켜 프로그램이 비정상 종료되도록 함
 
 
 def _tx(s: serial.Serial, buf: bytes) -> bool:
     try:
         written = s.write(buf)
-        s.flush()
+        s.flush() # 버퍼를 비워 즉시 전송
+        logging.debug(f"TX: {buf!r}") # 전송 내용 로깅 (디버그 레벨)
         return written == len(buf)
     except Exception as e:
         logging.error(f"TX 실패: {e}")
@@ -42,61 +55,100 @@ def _tx(s: serial.Serial, buf: bytes) -> bool:
 
 def _handshake(s: serial.Serial) -> bool:
     for i in range(RETRY_HANDSHAKE):
-        s.write(SYN); s.flush()
-        start = time.time()
-        while time.time() - start < HANDSHAKE_TIMEOUT:
-            if s.readline() == ACK:
-                logging.info("핸드셰이크 성공")
+        logging.info(f"핸드셰이크 시도 {i+1}/{RETRY_HANDSHAKE} - SYN 전송: {SYN!r}")
+        if not _tx(s, SYN): # _tx 함수를 사용하여 SYN 전송
+            logging.error(f"SYN 전송 실패 (시도 {i+1})")
+            time.sleep(1) # 실패 시 잠시 대기 후 재시도
+            continue
+        
+        # ACK 수신 로직: readline()은 \n을 만날 때까지 읽음
+        # s.timeout은 HANDSHAKE_TIMEOUT으로 설정되어 있음
+        received_line = s.readline() 
+        
+        if received_line:
+            logging.info(f"ACK 수신 시도: 받은 데이터: {received_line!r} (기대: {ACK!r})")
+            if received_line == ACK: # 정확히 ACK\n 인지 비교
+                logging.info("핸드셰이크 성공 (ACK 수신)")
                 return True
-        logging.warning(f"핸드셰이크 재시도 {i+1}/{RETRY_HANDSHAKE}")
+            else:
+                logging.warning(f"수신된 ACK 불일치: {received_line!r} vs {ACK!r}")
+        else:
+            # 타임아웃 발생 (readline()이 빈 바이트 문자열 반환)
+            logging.warning(f"ACK 수신 타임아웃 (시도 {i+1}/{RETRY_HANDSHAKE})")
+            
+    logging.error("핸드셰이크 최종 실패")
     return False
 
 
 def send_data(n: int = SEND_COUNT) -> int:
-
-    s = _open_serial()
+    try:
+        s = _open_serial()
+    except Exception: # _open_serial에서 예외 발생 시
+        logging.error("시리얼 포트 초기화 실패, 종료합니다.")
+        return 0
+        
     if not _handshake(s):
-        logging.error("핸드셰이크 최종 실패, 종료.")
+        logging.error("핸드셰이크 최종 실패, 종료합니다.")
         s.close()
         return 0
 
-    s.timeout = 0.1
+    s.timeout = 0.1 # 데이터 전송용 타임아웃 (짧게)
     sr = SensorReader()
     ok = 0
 
+    logging.info(f"--- {n}회 데이터 전송 시작 ---")
     for i in range(1, n + 1):
+        logging.debug(f"[{i}/{n}] 센서 데이터 읽기 시도...")
         sample = sr.get_sensor_data()
-        frames = make_frames(sample)
+        if not sample or not all(k in sample for k in ["ts", "accel", "gyro", "angle", "gps"]): # 주요 키 존재 확인
+            logging.warning(f"[{i}/{n}] 불완전 샘플 또는 빈 샘플, 건너뜀: {sample!r}")
+            time.sleep(1)
+            continue
+        
+        logging.debug(f"[{i}/{n}] 프레임 생성 시도...")
+        frames = make_frames(sample) # packetizer.py 호출
         if not frames:
-            logging.warning(f"[{i}/{n}] 불완전 샘플, 건너뜀")
+            # make_frames가 빈 리스트를 반환하는 경우는 packetizer.py 로직에 따라 다름
+            # (예: 압축 후 데이터가 너무 작거나 없을 때 등)
+            logging.warning(f"[{i}/{n}] make_frames 결과 없음, 건너뜀")
             time.sleep(1)
             continue
 
-        success = True
+        success_all_frames = True
+        logging.debug(f"[{i}/{n}] 총 {len(frames)}개 프레임 전송 시작...")
         for j, f in enumerate(frames, 1):
+            # f의 구조: [SEQ (1B)] [TOTAL (1B)] [PAYLOAD_CHUNK (최대 56B)]
+            # FRAME_MAX는 LEN 바이트를 제외한 f의 최대 길이
             if len(f) > FRAME_MAX:
-                logging.error(f"[{i}] 프레임 크기 초과: {len(f)}")
-                success = False
+                logging.error(f"[{i}/{n}] 프레임(f) 크기 초과: {len(f)} > {FRAME_MAX}")
+                success_all_frames = False
                 break
-            pkt = bytes([len(f)]) + f
+            
+            # pkt 구조: [LEN (1B)] + f
+            # LEN은 f의 길이
+            pkt = bytes([len(f)]) + f 
+            
+            logging.debug(f"[{i}/{n}] 프레임 {j}/{len(frames)} 전송 (LEN={len(f)}, pkt_total_len={len(pkt)}): {pkt!r}")
             if not _tx(s, pkt):
-                logging.error(f"[{i}] 프레임 {j}/{len(frames)} 전송 실패")
-                success = False
+                logging.error(f"[{i}/{n}] 프레임 {j}/{len(frames)} 전송 실패")
+                success_all_frames = False
                 break
-            time.sleep(DELAY_BETWEEN)
+            time.sleep(DELAY_BETWEEN) # 각 프레임 전송 후 딜레이
 
-        if success:
+        if success_all_frames:
             ok += 1
-            logging.info(f"[{i}/{n}] 전송 성공")
+            logging.info(f"[{i}/{n}] 전송 성공 (프레임 {len(frames)}개)")
         else:
             logging.error(f"[{i}/{n}] 전송 실패")
 
-        time.sleep(1)
+        time.sleep(1) # 다음 센서 데이터 샘플링 및 전송 사이의 딜레이
 
-    logging.info(f"총 {n}회 중 {ok}회 성공")
+    logging.info(f"총 {n}회 중 {ok}회 성공적으로 메시지 전송 완료")
     s.close()
     return ok
 
 
 if __name__ == "__main__":
+    # 더 자세한 로그를 보려면 아래 주석 해제
+    # logging.getLogger().setLevel(logging.DEBUG)
     send_data()

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import time, logging, serial, json, base64
+import time, logging, serial, json, base64, datetime # datetime 추가
 from typing import Any, Dict
 
+# 가정: e22_config, packetizer, encoder, sensor_reader 모듈은 동일 경로에 존재
 from e22_config import init_serial
 from packetizer import split_into_packets
 from encoder import compress_data
@@ -13,51 +14,177 @@ HEADER_SIZE = 2
 LORA_FRAME_LIMIT = 58
 JSON_OVERHEAD   = 29
 RAW_MAX_PER_PKT = 5     # 47B JSON (안전)
-MAX_RETRY = 3
+MAX_RETRY = 3 # 데이터 패킷 전송 재시도 횟수
+
+# 핸드셰이크 설정
+HANDSHAKE_TIMEOUT = 2.0 # ACK 응답 대기 시간 (초)
+SYN_MSG = b"SYN\r\n"    # 보낼 때는 bytes
+ACK_MSG = "ACK"         # 받을 때는 string으로 비교
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s - %(levelname)s - %(message)s")
 
-_open = lambda: (time.sleep(0.1), init_serial())[1]
+# 시리얼 포트 열기 함수 (에러 처리 강화)
+def _open_serial() -> serial.Serial | None:
+    try:
+        s = init_serial()
+        s.timeout = HANDSHAKE_TIMEOUT # ACK 수신을 위한 읽기 타임아웃 설정
+        time.sleep(0.1) # 안정화 시간
+        return s
+    except serial.SerialException as e:
+        logging.error(f"시리얼 포트 열기 실패: {e}")
+        return None
+    except Exception as e:
+        logging.error(f"시리얼 초기화 중 예외 발생: {e}")
+        return None
+
 _close = lambda s: s.is_open and s.close() if s else None
 
-
+# 데이터 전송 함수 (재시도 포함)
 def _tx(s: serial.Serial, buf: bytes) -> bool:
-    for _ in range(MAX_RETRY):
+    for attempt in range(MAX_RETRY):
         try:
-            if s.write(buf) == len(buf):
-                s.flush(); return True
+            written = s.write(buf)
+            if written == len(buf):
+                s.flush()
+                # logging.debug(f"TX ({written}B): {buf.decode('utf-8', errors='ignore').strip()}") # 디버깅용
+                return True
+            else:
+                logging.warning(f"부분 전송됨: {written}/{len(buf)} bytes (Attempt {attempt + 1}/{MAX_RETRY})")
         except serial.SerialException as e:
-            logging.error(e)
-        time.sleep(0.3)
+            logging.error(f"전송 실패: {e} (Attempt {attempt + 1}/{MAX_RETRY})")
+        except Exception as e:
+             logging.error(f"전송 중 예외: {e} (Attempt {attempt + 1}/{MAX_RETRY})")
+        time.sleep(0.3) # 재시도 전 잠시 대기
+    logging.error(f"최종 전송 실패: {buf.decode('utf-8', errors='ignore').strip()}")
     return False
+
+# 핸드셰이크 수행 함수
+def _do_handshake(s: serial.Serial) -> bool:
+    """SYN을 보내고 ACK를 기다립니다."""
+    logging.info("핸드셰이크 시작: SYN 전송 시도...")
+    if not _tx(s, SYN_MSG):
+        logging.error("핸드셰이크 실패: SYN 전송 실패")
+        return False
+
+    logging.info(f"SYN 전송 완료. {HANDSHAKE_TIMEOUT}초 동안 ACK 대기...")
+    try:
+        # ACK 응답 읽기 시도
+        ack_line_bytes = s.readline()
+        # logging.debug(f"Raw ACK received: {ack_line_bytes}") # 디버깅용
+
+        if ack_line_bytes:
+            ack_line = ack_line_bytes.decode('utf-8', errors='ignore').strip()
+            if ack_line == ACK_MSG:
+                logging.info("ACK 수신 성공. 핸드셰이크 완료.")
+                return True
+            else:
+                logging.warning(f"핸드셰이크 실패: 예상치 못한 응답 수신 '{ack_line}'")
+                return False
+        else:
+            # readline()이 비어있는 바이트를 반환하면 타임아웃 발생
+            logging.warning(f"핸드셰이크 실패: ACK 수신 타임아웃 ({HANDSHAKE_TIMEOUT}초)")
+            return False
+    except serial.SerialException as e:
+        logging.error(f"ACK 수신 중 시리얼 오류: {e}")
+        return False
+    except UnicodeDecodeError as ude:
+         logging.error(f"ACK 응답 디코딩 오류: {ude} (Raw: {ack_line_bytes})")
+         return False
+    except Exception as e:
+        logging.error(f"ACK 수신 중 예외 발생: {e}")
+        return False
 
 
 def _send_once(data: Dict[str, Any]) -> bool:
-    pkts = split_into_packets(compress_data(data), RAW_MAX_PER_PKT)
-    s = _open(); tot = len(pkts)
+    """핸드셰이크 후 데이터 패킷들을 전송합니다."""
+    s = _open_serial()
+    if not s:
+        return False # 포트 열기 실패
+
     try:
-        for p in pkts:
-            line = json.dumps({"seq": p["seq"], "total": tot,
-                              "payload": base64.b64encode(p["payload"]).decode()}) + "\r\n"
-            if len(line) > LORA_FRAME_LIMIT or not _tx(s, line.encode()):
-                return False
-            time.sleep(0.3)
+        # 1. 핸드셰이크 수행
+        if not _do_handshake(s):
+            return False # 핸드셰이크 실패 시 데이터 전송 안 함
+
+        # 2. 핸드셰이크 성공 시 데이터 준비 및 전송
+        compressed_data = compress_data(data)
+        if not compressed_data:
+            logging.error("데이터 압축 실패.")
+            return False
+
+        pkts = split_into_packets(compressed_data, RAW_MAX_PER_PKT)
+        tot = len(pkts)
+        logging.info(f"데이터 전송 시작: 총 {tot} 패킷")
+
+        # 중요: 데이터 전송 전 시리얼 타임아웃을 짧게 변경 (선택 사항)
+        # 핸드셰이크 후에는 읽을 일이 없으므로 타임아웃을 줄여 불필요한 대기 방지
+        s.timeout = 0.1 # 예: 100ms
+
+        for i, p in enumerate(pkts):
+            # 패킷 생성 (JSON + Base64)
+            packet_data = {
+                "seq": p["seq"],
+                "total": tot,
+                "payload": base64.b64encode(p["payload"]).decode()
+            }
+            line = json.dumps(packet_data) + "\r\n"
+            line_bytes = line.encode('utf-8')
+
+            # LoRa 프레임 크기 확인
+            if len(line_bytes) > LORA_FRAME_LIMIT:
+                 logging.error(f"패킷 크기 초과 ({len(line_bytes)} > {LORA_FRAME_LIMIT}): {line.strip()}")
+                 return False # 너무 큰 패킷은 전송 중단
+
+            # 패킷 전송 시도
+            logging.info(f"패킷 전송 ({i+1}/{tot}) - {len(line_bytes)} bytes")
+            if not _tx(s, line_bytes):
+                logging.error(f"패킷 {i+1}/{tot} 전송 실패.")
+                return False # 하나라도 전송 실패 시 중단
+
+            # LoRa 전송 간 딜레이 (필수)
+            time.sleep(0.3) # 패킷 간 간격 조절
+
+        logging.info(f"모든 패킷 ({tot}) 전송 완료.")
         return True
+
+    except Exception as e:
+        logging.error(f"_send_once 실행 중 예외 발생: {e}")
+        return False
     finally:
-        _close(s)
+        # 항상 시리얼 포트 닫기
+        if s and s.is_open:
+            logging.debug("시리얼 포트 닫는 중...")
+            s.close()
 
 
 def send_data(n: int = 100) -> int:
-    r, ok = SensorReader(), 0
+    """지정된 횟수(n)만큼 센서 데이터를 읽고 전송 시도"""
+    r = SensorReader()
+    ok = 0
     for i in range(1, n + 1):
-        logging.info(f"{i}/{n}")
-        if _send_once(r.get_sensor_data()):
+        logging.info(f"===== 전송 시도 {i}/{n} 시작 =====")
+        sensor_reading = r.get_sensor_data()
+        if not sensor_reading:
+            logging.warning(f"센서 데이터 읽기 실패 (시도 {i}/{n}).")
+            time.sleep(1) # 다음 시도 전 대기
+            continue
+
+        logging.info(f"전송할 데이터: {sensor_reading}")
+        if _send_once(sensor_reading):
+            logging.info(f"시도 {i}/{n} 성공.")
             ok += 1
         else:
-            break
+            logging.error(f"시도 {i}/{n} 실패.")
+            # 실패 시 바로 중단할지, 계속 시도할지 결정 가능
+            # break # 실패 시 중단하려면 주석 해제
+
+        # 각 전송 시도 후 잠시 대기 (LoRa 네트워크 부하 감소)
         time.sleep(1)
+        logging.info(f"===== 전송 시도 {i}/{n} 종료 =====")
+
+    logging.info(f"총 {n}번 시도 중 {ok}번 성공.")
     return ok
 
 if __name__ == "__main__":
-    logging.info(f"success {send_data()}")
+    send_data(5) # 테스트를 위해 횟수를 줄임

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,190 +1,75 @@
 # -*- coding: utf-8 -*-
+"""
+sender.py – LoRa 송신기
+· packetizer.make_frames() 로 받은 바이트를 실제로 전송
+"""
 from __future__ import annotations
+import time, logging, serial
+from typing import Any, Dict, List
 
-import time, logging, serial, json, base64, datetime # datetime 추가
-from typing import Any, Dict
-
-# 가정: e22_config, packetizer, encoder, sensor_reader 모듈은 동일 경로에 존재
-from e22_config import init_serial
-from packetizer import split_into_packets
-from encoder import compress_data
+from e22_config   import init_serial
+from packetizer   import make_frames
 from sensor_reader import SensorReader
 
-HEADER_SIZE = 2
-LORA_FRAME_LIMIT = 58
-JSON_OVERHEAD   = 29
-RAW_MAX_PER_PKT = 5     # 47B JSON (안전)
-MAX_RETRY = 3 # 데이터 패킷 전송 재시도 횟수
-
-# 핸드셰이크 설정
-HANDSHAKE_TIMEOUT = 2.0 # ACK 응답 대기 시간 (초)
-SYN_MSG = b"SYN\r\n"    # 보낼 때는 bytes
-ACK_MSG = "ACK"         # 받을 때는 string으로 비교
+# ────────── 설정 ──────────
+LORA_FRAME_LIMIT  = 58
+MAX_RETRY         = 3
+HANDSHAKE_TIMEOUT = 2.0
+SYN_MSG, ACK_MSG  = b"SYN\r\n", "ACK"
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s - %(levelname)s - %(message)s")
 
-# 시리얼 포트 열기 함수 (에러 처리 강화)
-def _open_serial() -> serial.Serial | None:
-    try:
-        s = init_serial()
-        s.timeout = HANDSHAKE_TIMEOUT # ACK 수신을 위한 읽기 타임아웃 설정
-        time.sleep(0.1) # 안정화 시간
-        return s
-    except serial.SerialException as e:
-        logging.error(f"시리얼 포트 열기 실패: {e}")
-        return None
-    except Exception as e:
-        logging.error(f"시리얼 초기화 중 예외 발생: {e}")
-        return None
+# ────────── 시리얼 유틸 ──────────
+def _open_serial() -> serial.Serial:
+    s = init_serial()
+    s.timeout = HANDSHAKE_TIMEOUT
+    time.sleep(0.1)
+    return s
 
-_close = lambda s: s.is_open and s.close() if s else None
-
-# 데이터 전송 함수 (재시도 포함)
 def _tx(s: serial.Serial, buf: bytes) -> bool:
-    for attempt in range(MAX_RETRY):
+    for _ in range(MAX_RETRY):
         try:
-            written = s.write(buf)
-            if written == len(buf):
-                s.flush()
-                # logging.debug(f"TX ({written}B): {buf.decode('utf-8', errors='ignore').strip()}") # 디버깅용
-                return True
-            else:
-                logging.warning(f"부분 전송됨: {written}/{len(buf)} bytes (Attempt {attempt + 1}/{MAX_RETRY})")
-        except serial.SerialException as e:
-            logging.error(f"전송 실패: {e} (Attempt {attempt + 1}/{MAX_RETRY})")
+            if s.write(buf) == len(buf):
+                s.flush(); return True
         except Exception as e:
-             logging.error(f"전송 중 예외: {e} (Attempt {attempt + 1}/{MAX_RETRY})")
-        time.sleep(0.3) # 재시도 전 잠시 대기
-    logging.error(f"최종 전송 실패: {buf.decode('utf-8', errors='ignore').strip()}")
+            logging.warning(f"TX 재시도: {e}")
+        time.sleep(0.3)
     return False
 
-# 핸드셰이크 수행 함수
-def _do_handshake(s: serial.Serial) -> bool:
-    """SYN을 보내고 ACK를 기다립니다."""
-    logging.info("핸드셰이크 시작: SYN 전송 시도...")
+def _handshake(s: serial.Serial) -> bool:
     if not _tx(s, SYN_MSG):
-        logging.error("핸드셰이크 실패: SYN 전송 실패")
         return False
+    return s.readline().decode(errors="ignore").strip() == ACK_MSG
 
-    logging.info(f"SYN 전송 완료. {HANDSHAKE_TIMEOUT}초 동안 ACK 대기...")
-    try:
-        # ACK 응답 읽기 시도
-        ack_line_bytes = s.readline()
-        # logging.debug(f"Raw ACK received: {ack_line_bytes}") # 디버깅용
-
-        if ack_line_bytes:
-            ack_line = ack_line_bytes.decode('utf-8', errors='ignore').strip()
-            if ack_line == ACK_MSG:
-                logging.info("ACK 수신 성공. 핸드셰이크 완료.")
-                return True
-            else:
-                logging.warning(f"핸드셰이크 실패: 예상치 못한 응답 수신 '{ack_line}'")
-                return False
-        else:
-            # readline()이 비어있는 바이트를 반환하면 타임아웃 발생
-            logging.warning(f"핸드셰이크 실패: ACK 수신 타임아웃 ({HANDSHAKE_TIMEOUT}초)")
-            return False
-    except serial.SerialException as e:
-        logging.error(f"ACK 수신 중 시리얼 오류: {e}")
-        return False
-    except UnicodeDecodeError as ude:
-         logging.error(f"ACK 응답 디코딩 오류: {ude} (Raw: {ack_line_bytes})")
-         return False
-    except Exception as e:
-        logging.error(f"ACK 수신 중 예외 발생: {e}")
-        return False
-
-
-def _send_once(data: Dict[str, Any]) -> bool:
-    """핸드셰이크 후 데이터 패킷들을 전송합니다."""
+# ────────── 전송 루틴 ──────────
+def send_sample(sample: Dict[str, Any]) -> bool:
     s = _open_serial()
-    if not s:
-        return False # 포트 열기 실패
-
     try:
-        # 1. 핸드셰이크 수행
-        if not _do_handshake(s):
-            return False # 핸드셰이크 실패 시 데이터 전송 안 함
+        if not _handshake(s):
+            logging.error("핸드셰이크 실패"); return False
 
-        # 2. 핸드셰이크 성공 시 데이터 준비 및 전송
-        compressed_data = compress_data(data)
-        if not compressed_data:
-            logging.error("데이터 압축 실패.")
-            return False
-
-        pkts = split_into_packets(compressed_data, RAW_MAX_PER_PKT)
-        tot = len(pkts)
-        logging.info(f"데이터 전송 시작: 총 {tot} 패킷")
-
-        # 중요: 데이터 전송 전 시리얼 타임아웃을 짧게 변경 (선택 사항)
-        # 핸드셰이크 후에는 읽을 일이 없으므로 타임아웃을 줄여 불필요한 대기 방지
-        s.timeout = 0.1 # 예: 100ms
-
-        for i, p in enumerate(pkts):
-            # 패킷 생성 (JSON + Base64)
-            packet_data = {
-                "seq": p["seq"],
-                "total": tot,
-                "payload": base64.b64encode(p["payload"]).decode()
-            }
-            line = json.dumps(packet_data) + "\r\n"
-            line_bytes = line.encode('utf-8')
-
-            # LoRa 프레임 크기 확인
-            if len(line_bytes) > LORA_FRAME_LIMIT:
-                 logging.error(f"패킷 크기 초과 ({len(line_bytes)} > {LORA_FRAME_LIMIT}): {line.strip()}")
-                 return False # 너무 큰 패킷은 전송 중단
-
-            # 패킷 전송 시도
-            logging.info(f"패킷 전송 ({i+1}/{tot}) - {len(line_bytes)} bytes")
-            if not _tx(s, line_bytes):
-                logging.error(f"패킷 {i+1}/{tot} 전송 실패.")
-                return False # 하나라도 전송 실패 시 중단
-
-            # LoRa 전송 간 딜레이 (필수)
-            time.sleep(0.3) # 패킷 간 간격 조절
-
-        logging.info(f"모든 패킷 ({tot}) 전송 완료.")
+        frames: List[bytes] = make_frames(sample)
+        s.timeout = 0.1
+        for i, f in enumerate(frames, 1):
+            if len(f) > LORA_FRAME_LIMIT:
+                raise ValueError("프레임 길이 초과")
+            if not _tx(s, f):
+                logging.error(f"{i}/{len(frames)} 전송 실패"); return False
+            time.sleep(0.3)
+        logging.info(f"✓ {len(frames)}개 프레임 전송 완료")
         return True
-
-    except Exception as e:
-        logging.error(f"_send_once 실행 중 예외 발생: {e}")
-        return False
     finally:
-        # 항상 시리얼 포트 닫기
-        if s and s.is_open:
-            logging.debug("시리얼 포트 닫는 중...")
-            s.close()
-
+        s.close()
 
 def send_data(n: int = 100) -> int:
-    """지정된 횟수(n)만큼 센서 데이터를 읽고 전송 시도"""
-    r = SensorReader()
-    ok = 0
+    r, ok = SensorReader(), 0
     for i in range(1, n + 1):
-        logging.info(f"===== 전송 시도 {i}/{n} 시작 =====")
-        sensor_reading = r.get_sensor_data()
-        if not sensor_reading:
-            logging.warning(f"센서 데이터 읽기 실패 (시도 {i}/{n}).")
-            time.sleep(1) # 다음 시도 전 대기
-            continue
-
-        logging.info(f"전송할 데이터: {sensor_reading}")
-        if _send_once(sensor_reading):
-            logging.info(f"시도 {i}/{n} 성공.")
+        if send_sample(r.get_sensor_data()):
             ok += 1
-        else:
-            logging.error(f"시도 {i}/{n} 실패.")
-            # 실패 시 바로 중단할지, 계속 시도할지 결정 가능
-            # break # 실패 시 중단하려면 주석 해제
-
-        # 각 전송 시도 후 잠시 대기 (LoRa 네트워크 부하 감소)
         time.sleep(1)
-        logging.info(f"===== 전송 시도 {i}/{n} 종료 =====")
-
-    logging.info(f"총 {n}번 시도 중 {ok}번 성공.")
+    logging.info(f"{n}회 중 {ok}회 성공")
     return ok
 
 if __name__ == "__main__":
-    send_data(5) # 테스트를 위해 횟수를 줄임
+    send_data(5)     # 짧게 테스트

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-sender.py — LoRa 트랜스미터 (LEN-SEQ-TOTAL-PAYLOAD)  
-· compress_data() 실패 시 건너뜀  
-· 1 000회 전송, 핸드셰이크 5회 재시도
+sender.py — LoRa 트랜스미터 (한 번만 SYN/ACK → 1000회 연속 프레임 전송)
 """
 from __future__ import annotations
 import time, logging, serial
@@ -18,7 +16,6 @@ FRAME_MAX         = 2 + MAX_PAYLOAD
 HANDSHAKE_TIMEOUT = 2.0
 SEND_COUNT        = 1000
 RETRY_HANDSHAKE   = 5
-RETRY_TX          = 3
 DELAY_BETWEEN     = 0.3
 
 SYN = b"SYN\r\n"
@@ -36,67 +33,70 @@ def _open_serial() -> serial.Serial:
 
 
 def _tx(s: serial.Serial, buf: bytes) -> bool:
-    for _ in range(RETRY_TX):
-        try:
-            if s.write(buf) == len(buf):
-                s.flush()
-                return True
-        except Exception as e:
-            logging.warning(f"TX 재시도: {e}")
-        time.sleep(DELAY_BETWEEN)
-    return False
+    try:
+        written = s.write(buf)
+        s.flush()
+        return written == len(buf)
+    except Exception as e:
+        logging.error(f"TX 실패: {e}")
+        return False
 
 
 def _handshake(s: serial.Serial) -> bool:
-    # SYN→ACK 5회 재시도
-    for attempt in range(RETRY_HANDSHAKE):
+    for i in range(RETRY_HANDSHAKE):
         s.write(SYN); s.flush()
         start = time.time()
         while time.time() - start < HANDSHAKE_TIMEOUT:
-            resp = s.readline()
-            if resp == ACK:
+            if s.readline() == ACK:
+                logging.info("핸드셰이크 성공")
                 return True
-        logging.warning(f"핸드셰이크 재시도 {attempt+1}/{RETRY_HANDSHAKE}")
+        logging.warning(f"핸드셰이크 재시도 {i+1}/{RETRY_HANDSHAKE}")
     return False
 
 
-def send_sample(sample: Dict[str, Any]) -> bool:
-    # 1) 직렬화 방어
-    frames = make_frames(sample)
-    if not frames:
-        return False
-
-    # 2) 포트 열고 핸드셰이크
+def send_data(n: int = SEND_COUNT) -> int:
+    """한 번 핸드셰이크 → n회 센서 읽고 프레임 전송"""
     s = _open_serial()
-    try:
-        if not _handshake(s):
-            logging.error("핸드셰이크 실패")
-            return False
+    if not _handshake(s):
+        logging.error("핸드셰이크 최종 실패, 종료합니다.")
+        s.close()
+        return 0
 
-        # 3) 프레임 전송 (LEN + [seq,total] + payload)
-        s.timeout = 0.1
-        for i, f in enumerate(frames, 1):
+    s.timeout = 0.1
+    sr = SensorReader()
+    ok = 0
+
+    for i in range(1, n + 1):
+        sample = sr.get_sensor_data()
+        frames = make_frames(sample)
+        if not frames:
+            logging.warning(f"[{i}/{n}] 불완전 샘플, 건너뜀")
+            time.sleep(1)
+            continue
+
+        success = True
+        for j, f in enumerate(frames, 1):
             if len(f) > FRAME_MAX:
-                raise ValueError("프레임 길이 초과")
+                logging.error(f"[{i}] 프레임 크기 초과: {len(f)}")
+                success = False
+                break
             pkt = bytes([len(f)]) + f
             if not _tx(s, pkt):
-                logging.error(f"{i}/{len(frames)} 전송 실패")
-                return False
+                logging.error(f"[{i}] 프레임 {j}/{len(frames)} 전송 실패")
+                success = False
+                break
             time.sleep(DELAY_BETWEEN)
-        logging.info(f"✓ {len(frames)}개 프레임 전송 완료")
-        return True
 
-    finally:
-        s.close()
-
-
-def send_data(n: int = SEND_COUNT) -> int:
-    sr, ok = SensorReader(), 0
-    for i in range(1, n + 1):
-        if send_sample(sr.get_sensor_data()):
+        if success:
             ok += 1
+            logging.info(f"[{i}/{n}] 전송 성공")
+        else:
+            logging.error(f"[{i}/{n}] 전송 실패")
+
         time.sleep(1)
-    logging.info(f"{n}회 중 {ok}회 성공")
+
+    logging.info(f"총 {n}회 중 {ok}회 성공")
+    s.close()
     return ok
 
 

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,117 +1,63 @@
-# sender.py
-import time
-import logging
-import serial
-import json
-import base64
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import time, logging, serial, json, base64
+from typing import Any, Dict
 
 from e22_config import init_serial
 from packetizer import split_into_packets
 from encoder import compress_data
-from sensor_reader import SensorReader  # 센서 리더 모듈 임포트
+from sensor_reader import SensorReader
 
-# 로깅 설정
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
-
-# 패킷당 최대 LoRa 전송 바이트 수 (헤더 포함)
 HEADER_SIZE = 2
-MAX_PAYLOAD_SIZE = 50 - HEADER_SIZE
+LORA_FRAME_LIMIT = 58
+JSON_OVERHEAD   = 29
+RAW_MAX_PER_PKT = 5     # 47B JSON (안전)
+MAX_RETRY = 3
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s - %(levelname)s - %(message)s")
+
+_open = lambda: (time.sleep(0.1), init_serial())[1]
+_close = lambda s: s.is_open and s.close() if s else None
 
 
-def open_serial():
-    """
-    시리얼 포트를 초기화하여 반환합니다.
-    """
-    ser = init_serial()
-    logging.info(f"시리얼 포트 열림: {ser.port} @ {ser.baudrate}bps")
-    time.sleep(0.1)
-    return ser
+def _tx(s: serial.Serial, buf: bytes) -> bool:
+    for _ in range(MAX_RETRY):
+        try:
+            if s.write(buf) == len(buf):
+                s.flush(); return True
+        except serial.SerialException as e:
+            logging.error(e)
+        time.sleep(0.3)
+    return False
 
 
-def close_serial(ser):
-    """
-    열린 시리얼 포트를 닫습니다.
-    """
-    if ser and ser.is_open:
-        ser.close()
-        logging.info("시리얼 포트 닫힘")
-
-
-def send_packet(ser, data: bytes) -> bool:
-    """
-    단일 LoRa 패킷(바이너리)을 전송합니다.
-    """
+def _send_once(data: Dict[str, Any]) -> bool:
+    pkts = split_into_packets(compress_data(data), RAW_MAX_PER_PKT)
+    s = _open(); tot = len(pkts)
     try:
-        written = ser.write(data)
-        ser.flush()
-        if written == len(data):
-            logging.info(f"패킷 전송 성공 ({written}/{len(data)} bytes)")
-            return True
-        logging.warning(f"부분 전송 발생 ({written}/{len(data)} bytes)")
-        return False
-    except serial.SerialException as e:
-        logging.error(f"시리얼 오류: {e}")
-        return False
-
-
-def _send_once(data_obj) -> bool:
-    """
-    주어진 센서 데이터 객체를 한 번 전송합니다.
-    JSON 직렬화→zlib 압축→패킷 분할→Base64 인코딩→JSON 전송
-    """
-    compressed = compress_data(data_obj)
-    packets = split_into_packets(compressed, max_size=MAX_PAYLOAD_SIZE)
-    total = len(packets)
-    logging.info(f"[단일 전송] 총 {total}개의 패킷 분할됨")
-
-    ser = open_serial()
-    try:
-        for pkt in packets:
-            seq = pkt['seq']
-            payload = pkt['payload']
-            b64 = base64.b64encode(payload).decode('ascii')
-            packet_json = json.dumps({'seq': seq, 'total': total, 'payload': b64}) + '\n'
-            if not send_packet(ser, packet_json.encode('utf-8')):
-                logging.error(f"패킷 {seq}/{total} 전송 실패, 중단")
+        for p in pkts:
+            line = json.dumps({"seq": p["seq"], "total": tot,
+                              "payload": base64.b64encode(p["payload"]).decode()}) + "\r\n"
+            if len(line) > LORA_FRAME_LIMIT or not _tx(s, line.encode()):
                 return False
-            time.sleep(0.05)
-        logging.info("[단일 전송] 완료")
+            time.sleep(0.3)
         return True
     finally:
-        close_serial(ser)
+        _close(s)
 
 
-def send_data(count: int = 100) -> int:
-    """
-    SensorReader를 이용해 센서 데이터를 count회 연속 전송합니다.
-
-    Args:
-        count: 전송 반복 횟수 (기본값 100)
-    Returns:
-        성공적으로 전송된 횟수
-    """
-    reader = SensorReader()
-    success = 0
-    for i in range(1, count + 1):
-        data = reader.get_sensor_data()
-        logging.info(f"[반복 전송] {i}/{count}번째 전송 시작 - 데이터: {data}")
-        if _send_once(data):
-            success += 1
+def send_data(n: int = 100) -> int:
+    r, ok = SensorReader(), 0
+    for i in range(1, n + 1):
+        logging.info(f"{i}/{n}")
+        if _send_once(r.get_sensor_data()):
+            ok += 1
         else:
-            logging.error(f"[반복 전송] {i}/{count}번째 전송 실패, 중단")
             break
-        # 전송 간 1초 대기
         time.sleep(1)
-    logging.info(f"[반복 전송] 완료: {success}/{count} 성공")
-    return success
+    return ok
 
-
-# 테스트 코드
-if __name__ == '__main__':
-    # 반복 전송 테스트
-    logging.info("[테스트] send_data() 반복 전송 테스트 시작 (기본 100회)")
-    result_count = send_data()
-    logging.info(f"[테스트] send_data 결과: {result_count}/100 성공")
+if __name__ == "__main__":
+    logging.info(f"success {send_data()}")

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -102,6 +102,8 @@ def send_data(obj, count: int = 100) -> int:
         else:
             logging.error(f"[반복 전송] {i}/{count}번째 전송 실패, 중단")
             break
+        # 전송 간 간격: 1초
+        time.sleep(1)
     logging.info(f"[반복 전송] 완료: {success}/{count} 성공")
     return success
 
@@ -119,3 +121,4 @@ if __name__ == '__main__':
     # 반복 전송 테스트
     logging.info("[테스트] send_data() 반복 전송 테스트 시작 (기본 100회)")
     result_count = send_data(sample_obj)
+    logging.info(f"[테스트] send_data 결과: {result_count}/100 성공")

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,27 +1,27 @@
 # -*- coding: utf-8 -*-
 """
-sender.py – LoRa 송신기
-· packetizer.make_frames() 로 받은 바이트를 실제로 전송
+sender.py – LoRa 송신
+· packetizer.make_frames() → 2 B 헤더 + payload
+· 프레임 끝에 '\n' 추가하여 경계 표시
 """
 from __future__ import annotations
 import time, logging, serial
-from typing import Any, Dict, List
+from typing import Dict, Any, List
 
-from e22_config   import init_serial
-from packetizer   import make_frames
+from e22_config    import init_serial
+from packetizer    import make_frames
 from sensor_reader import SensorReader
 
-# ────────── 설정 ──────────
-LORA_FRAME_LIMIT  = 58
+LORA_FRAME_LIMIT  = 58          # 2B 헤더 + 56B payload
 MAX_RETRY         = 3
 HANDSHAKE_TIMEOUT = 2.0
-SYN_MSG, ACK_MSG  = b"SYN\r\n", "ACK"
+SYN, ACK          = b"SYN\r\n", b"ACK\n"
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s - %(levelname)s - %(message)s")
 
 # ────────── 시리얼 유틸 ──────────
-def _open_serial() -> serial.Serial:
+def _open() -> serial.Serial:
     s = init_serial()
     s.timeout = HANDSHAKE_TIMEOUT
     time.sleep(0.1)
@@ -38,13 +38,11 @@ def _tx(s: serial.Serial, buf: bytes) -> bool:
     return False
 
 def _handshake(s: serial.Serial) -> bool:
-    if not _tx(s, SYN_MSG):
-        return False
-    return s.readline().decode(errors="ignore").strip() == ACK_MSG
+    return _tx(s, SYN) and s.readline() == ACK
 
 # ────────── 전송 루틴 ──────────
 def send_sample(sample: Dict[str, Any]) -> bool:
-    s = _open_serial()
+    s = _open()
     try:
         if not _handshake(s):
             logging.error("핸드셰이크 실패"); return False
@@ -54,7 +52,8 @@ def send_sample(sample: Dict[str, Any]) -> bool:
         for i, f in enumerate(frames, 1):
             if len(f) > LORA_FRAME_LIMIT:
                 raise ValueError("프레임 길이 초과")
-            if not _tx(s, f):
+            # 프레임 + LF → 경계
+            if not _tx(s, f + b'\n'):
                 logging.error(f"{i}/{len(frames)} 전송 실패"); return False
             time.sleep(0.3)
         logging.info(f"✓ {len(frames)}개 프레임 전송 완료")
@@ -63,13 +62,13 @@ def send_sample(sample: Dict[str, Any]) -> bool:
         s.close()
 
 def send_data(n: int = 100) -> int:
-    r, ok = SensorReader(), 0
+    sr, ok = SensorReader(), 0
     for i in range(1, n + 1):
-        if send_sample(r.get_sensor_data()):
+        if send_sample(sr.get_sensor_data()):
             ok += 1
         time.sleep(1)
     logging.info(f"{n}회 중 {ok}회 성공")
     return ok
 
 if __name__ == "__main__":
-    send_data(5)     # 짧게 테스트
+    send_data(5)

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-sender.py — LoRa 트랜스미터 (LEN-SEQ-TOTAL-PAYLOAD)
-· compress_data() 실패 시 건너뜀
-· 기본 1000회 전송
+sender.py — LoRa 트랜스미터 (LEN-SEQ-TOTAL-PAYLOAD)  
+· compress_data() 실패 시 건너뜀  
+· 1 000회 전송, 핸드셰이크 5회 재시도
 """
 from __future__ import annotations
 import time, logging, serial
@@ -13,13 +13,16 @@ from packetizer    import make_frames
 from sensor_reader import SensorReader
 
 # ────────── 설정 ──────────
-MAX_PAYLOAD       = 56            # packetizer.py와 동일
+MAX_PAYLOAD       = 56
 FRAME_MAX         = 2 + MAX_PAYLOAD
 HANDSHAKE_TIMEOUT = 2.0
 SEND_COUNT        = 1000
+RETRY_HANDSHAKE   = 5
+RETRY_TX          = 3
+DELAY_BETWEEN     = 0.3
 
-SYN = b"SYN\n"
-ACK = b"ACK\n"
+SYN = b"SYN\r\n"
+ACK = b"ACK\r\n"
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s - %(levelname)s - %(message)s")
@@ -33,38 +36,44 @@ def _open_serial() -> serial.Serial:
 
 
 def _tx(s: serial.Serial, buf: bytes) -> bool:
-    for _ in range(3):
+    for _ in range(RETRY_TX):
         try:
             if s.write(buf) == len(buf):
                 s.flush()
                 return True
         except Exception as e:
             logging.warning(f"TX 재시도: {e}")
-        time.sleep(0.3)
+        time.sleep(DELAY_BETWEEN)
     return False
 
 
 def _handshake(s: serial.Serial) -> bool:
-    if not _tx(s, SYN):
-        return False
-    resp = s.readline()
-    return resp == ACK
+    # SYN→ACK 5회 재시도
+    for attempt in range(RETRY_HANDSHAKE):
+        s.write(SYN); s.flush()
+        start = time.time()
+        while time.time() - start < HANDSHAKE_TIMEOUT:
+            resp = s.readline()
+            if resp == ACK:
+                return True
+        logging.warning(f"핸드셰이크 재시도 {attempt+1}/{RETRY_HANDSHAKE}")
+    return False
 
 
 def send_sample(sample: Dict[str, Any]) -> bool:
-    # 1) 직렬화·압축 실패(불완전 샘플) 방어
-    frames: List[bytes] = make_frames(sample)
+    # 1) 직렬화 방어
+    frames = make_frames(sample)
     if not frames:
         return False
 
-    # 2) 시리얼 오픈 + 핸드셰이크
+    # 2) 포트 열고 핸드셰이크
     s = _open_serial()
     try:
         if not _handshake(s):
             logging.error("핸드셰이크 실패")
             return False
 
-        # 3) 프레임 전송 (LEN 바이트 + [SEQ, TOTAL] + payload)
+        # 3) 프레임 전송 (LEN + [seq,total] + payload)
         s.timeout = 0.1
         for i, f in enumerate(frames, 1):
             if len(f) > FRAME_MAX:
@@ -73,7 +82,7 @@ def send_sample(sample: Dict[str, Any]) -> bool:
             if not _tx(s, pkt):
                 logging.error(f"{i}/{len(frames)} 전송 실패")
                 return False
-            time.sleep(0.3)
+            time.sleep(DELAY_BETWEEN)
         logging.info(f"✓ {len(frames)}개 프레임 전송 완료")
         return True
 

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-sender.py — LoRa 트랜스미터 (한 번만 SYN/ACK → 1000회 연속 프레임 전송)
-"""
+
 from __future__ import annotations
 import time, logging, serial
 from typing import Any, Dict, List
@@ -55,10 +53,10 @@ def _handshake(s: serial.Serial) -> bool:
 
 
 def send_data(n: int = SEND_COUNT) -> int:
-    """한 번 핸드셰이크 → n회 센서 읽고 프레임 전송"""
+
     s = _open_serial()
     if not _handshake(s):
-        logging.error("핸드셰이크 최종 실패, 종료합니다.")
+        logging.error("핸드셰이크 최종 실패, 종료.")
         s.close()
         return 0
 

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -2,13 +2,12 @@
 import time
 import logging
 import serial
-import argparse
 import json
 import base64
 
 from e22_config import init_serial
-from packetizer import split_into_packets  # 바이너리 분할 로직
-from encoder import compress_data         # zlib 압축 로직
+from packetizer import split_into_packets
+from encoder import compress_data
 
 # 로깅 설정
 logging.basicConfig(
@@ -16,9 +15,9 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 
-# 패킷당 최대 LoRa 전송 바이트 수(헤더 포함)
-HEADER_SIZE = 2  # seq(1 byte) + total(1 byte)
-MAX_PAYLOAD_SIZE = 50 - HEADER_SIZE  # raw 바이너리 기준
+# 패킷당 최대 LoRa 전송 바이트 수 (헤더 포함)
+HEADER_SIZE = 2
+MAX_PAYLOAD_SIZE = 50 - HEADER_SIZE
 
 
 def open_serial():
@@ -58,70 +57,65 @@ def send_packet(ser, data: bytes) -> bool:
         return False
 
 
-def send_data(obj) -> bool:
+def _send_once(obj) -> bool:
     """
-    Python 객체를 JSON 직렬화 → zlib 압축 → 패킷 분할 → Base64 인코딩 → JSON 전송
-
-    Args:
-        obj: JSON 직렬화 가능한 Python 객체
-    Returns:
-        bool: 전체 전송 성공 시 True
+    Python 객체를 한 번 전송합니다.
+    객체를 JSON 직렬화→zlib 압축→패킷 분할→Base64 인코딩→JSON 전송
     """
-    # 1) JSON 직렬화 + zlib 압축
     compressed = compress_data(obj)
-
-    # 2) raw 바이너리 분할
     packets = split_into_packets(compressed, max_size=MAX_PAYLOAD_SIZE)
     total = len(packets)
-    logging.info(f"총 {total}개의 패킷으로 분할됨")
+    logging.info(f"[단일 전송] 총 {total}개의 패킷 분할됨")
 
-    # 3) 시리얼 오픈
     ser = open_serial()
     try:
         for pkt in packets:
             seq = pkt['seq']
-            payload = pkt['payload']  # raw 바이너리
-
-            # 4) Base64 인코딩 + JSON 포맷
+            payload = pkt['payload']
             b64 = base64.b64encode(payload).decode('ascii')
-            packet_json = json.dumps({
-                'seq': seq,
-                'total': total,
-                'payload': b64
-            }) + '\n'
-
-            # 5) JSON 텍스트 전송
-            logging.info(f"패킷 {seq}/{total} 전송 중...")
+            packet_json = json.dumps({'seq': seq, 'total': total, 'payload': b64}) + '\n'
             if not send_packet(ser, packet_json.encode('utf-8')):
-                logging.error(f"패킷 {seq} 전송 실패. 중단합니다.")
+                logging.error(f"패킷 {seq}/{total} 전송 실패, 중단")
                 return False
-
             time.sleep(0.05)
-
-        logging.info("모든 패킷 전송 완료")
+        logging.info("[단일 전송] 완료")
         return True
-
     finally:
         close_serial(ser)
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='LoRa 송신 테스트 유틸리티')
-    parser.add_argument('--mode', choices=['packet', 'data'], default='data',
-                        help='packet: raw 바이너리 테스트, data: 센서 데이터 전송')
-    args = parser.parse_args()
+def send_data(obj, count: int = 100) -> int:
+    """
+    주어진 객체를 지정한 횟수만큼 연속 전송합니다.
 
-    if args.mode == 'packet':
-        # 단일 raw 패킷 전송 테스트
-        ser = open_serial()
-        result = send_packet(ser, b'\xAA\xBBTESTPACKET')
-        logging.info(f"send_packet 결과: {'성공' if result else '실패'}")
-        close_serial(ser)
-    else:
-        # 센서 데이터 전송 테스트
-        import sensor_reader
-        reader = sensor_reader.SensorReader()
-        data = reader.get_sensor_data()
-        logging.info("[테스트] send_data 함수 실행")
-        result = send_data(data)
-        logging.info(f"send_data 결과: {'성공' if result else '실패'}")
+    Args:
+        obj: JSON 직렬화 가능한 Python 객체
+        count: 전송 반복 횟수 (기본값 100)
+    Returns:
+        성공적으로 전송된 횟수
+    """
+    success = 0
+    for i in range(1, count + 1):
+        logging.info(f"[반복 전송] {i}/{count}번째 전송 시작")
+        if _send_once(obj):
+            success += 1
+        else:
+            logging.error(f"[반복 전송] {i}/{count}번째 전송 실패, 중단")
+            break
+    logging.info(f"[반복 전송] 완료: {success}/{count} 성공")
+    return success
+
+
+# 테스트 코드
+if __name__ == '__main__':
+    # 샘플 데이터 생성
+    sample_obj = {'message': 'Hello Test', 'value': 42, 'timestamp': time.time()}
+
+    # 단일 전송 테스트
+    logging.info("[테스트] _send_once() 단일 전송 테스트 시작")
+    result_once = _send_once(sample_obj)
+    logging.info(f"[테스트] _send_once 결과: {'성공' if result_once else '실패'}")
+
+    # 반복 전송 테스트
+    logging.info("[테스트] send_data() 반복 전송 테스트 시작 (기본 100회)")
+    result_count = send_data(sample_obj)

--- a/source/transmitter/sender.py
+++ b/source/transmitter/sender.py
@@ -1,60 +1,87 @@
 # -*- coding: utf-8 -*-
 """
-sender.py – LoRa 송신 (LEN‑SEQ‑TOTAL‑PAYLOAD)
+sender.py — LoRa 트랜스미터 (LEN-SEQ-TOTAL-PAYLOAD)
+· compress_data() 실패 시 건너뜀
+· 기본 1000회 전송
 """
 from __future__ import annotations
 import time, logging, serial
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 from e22_config    import init_serial
-from packetizer    import make_frames          # 2B 헤더+payload 리스트 생성
+from packetizer    import make_frames
 from sensor_reader import SensorReader
 
-MAX_PAYLOAD      = 56          # packetizer와 동일
-FRAME_MAX        = 2 + MAX_PAYLOAD           # 헤더+payload
-LEN_MAX          = FRAME_MAX                 # LEN 값
+# ────────── 설정 ──────────
+MAX_PAYLOAD       = 56            # packetizer.py와 동일
+FRAME_MAX         = 2 + MAX_PAYLOAD
 HANDSHAKE_TIMEOUT = 2.0
+SEND_COUNT        = 1000
 
-SYN, ACK = b"SYN\r\n", b"ACK\n"
+SYN = b"SYN\n"
+ACK = b"ACK\n"
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s - %(levelname)s - %(message)s")
 
-def _open() -> serial.Serial:
+
+def _open_serial() -> serial.Serial:
     s = init_serial()
     s.timeout = HANDSHAKE_TIMEOUT
     time.sleep(0.1)
     return s
 
+
 def _tx(s: serial.Serial, buf: bytes) -> bool:
-    try:
-        s.write(buf); s.flush(); return True
-    except Exception as e:
-        logging.error(f"TX 실패: {e}"); return False
+    for _ in range(3):
+        try:
+            if s.write(buf) == len(buf):
+                s.flush()
+                return True
+        except Exception as e:
+            logging.warning(f"TX 재시도: {e}")
+        time.sleep(0.3)
+    return False
+
 
 def _handshake(s: serial.Serial) -> bool:
-    return _tx(s, SYN) and s.readline() == ACK
+    if not _tx(s, SYN):
+        return False
+    resp = s.readline()
+    return resp == ACK
 
-# ────────── 전송 루틴 ──────────
+
 def send_sample(sample: Dict[str, Any]) -> bool:
-    s = _open()
+    # 1) 직렬화·압축 실패(불완전 샘플) 방어
+    frames: List[bytes] = make_frames(sample)
+    if not frames:
+        return False
+
+    # 2) 시리얼 오픈 + 핸드셰이크
+    s = _open_serial()
     try:
         if not _handshake(s):
-            logging.error("핸드셰이크 실패"); return False
+            logging.error("핸드셰이크 실패")
+            return False
 
-        frames: List[bytes] = make_frames(sample)   # 2B 헤더+payload
-        for f in frames:
+        # 3) 프레임 전송 (LEN 바이트 + [SEQ, TOTAL] + payload)
+        s.timeout = 0.1
+        for i, f in enumerate(frames, 1):
             if len(f) > FRAME_MAX:
                 raise ValueError("프레임 길이 초과")
-            pkt = bytes([len(f)]) + f               # LEN + 본문
+            pkt = bytes([len(f)]) + f
             if not _tx(s, pkt):
+                logging.error(f"{i}/{len(frames)} 전송 실패")
                 return False
-            time.sleep(0.3)                         # LoRa 채널 보호
+            time.sleep(0.3)
+        logging.info(f"✓ {len(frames)}개 프레임 전송 완료")
         return True
+
     finally:
         s.close()
 
-def send_data(n: int = 1000) -> int:               # 기본 1000회
+
+def send_data(n: int = SEND_COUNT) -> int:
     sr, ok = SensorReader(), 0
     for i in range(1, n + 1):
         if send_sample(sr.get_sensor_data()):
@@ -63,5 +90,6 @@ def send_data(n: int = 1000) -> int:               # 기본 1000회
     logging.info(f"{n}회 중 {ok}회 성공")
     return ok
 
+
 if __name__ == "__main__":
-    send_data()         # 1 000회 실행
+    send_data()

--- a/source/transmitter/sensor_reader.py
+++ b/source/transmitter/sensor_reader.py
@@ -1,38 +1,112 @@
-import random
+# -*- coding: utf-8 -*-
+"""sensor_reader.py – 실 MPU6050 + 모형 GPS
+· UART 115200 @ /dev/ttyAMA2 (env MPU_PORT 로 변경 가능)
+· 핸드오프 실패 시 Mock MPU로 자동 대체
+· get_sensor_data() → 실시간 딕트 반환
+· run_logger() – data/raw/ 에 JSONL + CSV 1 000 샘플 저장
+"""
 
+from __future__ import annotations
+
+import os, time, json, csv, struct, serial, logging, random
+from collections import deque
+
+# ────────── 설정 ──────────
+MPU_PORT = os.getenv("MPU_PORT", "/dev/ttyAMA2")  # 기본 포트
+MPU_BAUD = 115200
+LOG_DIR  = "data/raw"; os.makedirs(LOG_DIR, exist_ok=True)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+# ────────── MPU 파서 ──────────
+class _RealMPU:
+    def __init__(self, port: str):
+        self.ser = serial.Serial(port, MPU_BAUD, timeout=0.05)
+        self.buf: deque[int] = deque()
+        self.last: dict = {}
+        logging.info(f"MPU 연결 성공: {port}")
+
+    def _s16(self, b):
+        return struct.unpack('<h', b)[0]
+
+    def _parse(self, p: bytes):
+        if p[0] != 0x55: return None
+        kind = p[1]
+        if kind == 0x51:
+            return {"accel": {
+                "ax": self._s16(p[2:4]) / 32768 * 16,
+                "ay": self._s16(p[4:6]) / 32768 * 16,
+                "az": self._s16(p[6:8]) / 32768 * 16}}
+        if kind == 0x52:
+            return {"gyro": {
+                "gx": self._s16(p[2:4]) / 32768 * 2000,
+                "gy": self._s16(p[4:6]) / 32768 * 2000,
+                "gz": self._s16(p[6:8]) / 32768 * 2000}}
+        if kind == 0x53:
+            return {"angle": {
+                "roll":  self._s16(p[2:4]) / 32768 * 180,
+                "pitch": self._s16(p[4:6]) / 32768 * 180,
+                "yaw":   self._s16(p[6:8]) / 32768 * 180}}
+        return None
+
+    def poll(self):
+        self.buf.extend(self.ser.read(33))
+        updated = {}
+        while len(self.buf) >= 11:
+            if self.buf[0] != 0x55:
+                self.buf.popleft(); continue
+            pkt = bytes([self.buf.popleft() for _ in range(11)])
+            r = self._parse(pkt)
+            if r: updated.update(r)
+        if updated: self.last.update(updated)
+        return self.last or None
+
+# ────────── Mock MPU / GPS ──────────
+class _MockMPU:
+    def poll(self):
+        return {
+            "accel": {k: round(random.uniform(-2, 2), 2) for k in ("ax", "ay", "az")},
+            "gyro":  {k: round(random.uniform(-250, 250), 1) for k in ("gx", "gy", "gz")},
+            "angle": {k: round(random.uniform(-180, 180), 1) for k in ("roll", "pitch", "yaw")},
+        }
+
+class _MockGPS:
+    def poll(self):
+        return {"lat": round(random.uniform(33, 38), 6), "lon": round(random.uniform(126, 130), 6)}
+
+# ────────── SensorReader ──────────
 class SensorReader:
     def __init__(self):
-        pass
-    def _mock_accel_data(self):
-        #임의 가속 데이터
-        return {
-            "x": round(random.uniform(-2.0,2.0), 2),
-            "y": round(random.uniform(-2.0,2.0), 2),
-            "z": round(random.uniform(9.5,10.5), 2)
-        }
-    def _mock_gyro_data(self):
-        #임의 자이로 데이터 
-        return {
-            "x": round(random.uniform(-250.0,250.0),1),
-            "y": round(random.uniform(-250.0,250.0),1),
-            "z": round(random.uniform(-250.0,250.0),1)
-        }
-    def _mock_gps_data(self):
-        #임의 GPS 데이터
-        return {
-            "lat": round(random.uniform(33.0, 38.0), 5),
-            "lon": round(random.uniform(126.0, 130.0), 5)
-        }
-    
-    def get_sensor_data(self) -> dict:
-        return{
-            # caution: mock data
-            "accel":self._mock_accel_data(),\
-            "gyro":self._mock_gyro_data(),\
-            "gps":self._mock_gps_data()\
-        }
-    
-'''if __name__ == "__main__":
-    sensor_reader = SensorReader()
-    data = sensor_reader.get_sensor_data()
-    print(data)'''
+        try:
+            self.m = _RealMPU(MPU_PORT)
+        except (serial.SerialException, FileNotFoundError, OSError) as e:
+            logging.warning(f"MPU 포트 열기 실패({e}) → Mock MPU 사용")
+            self.m = _MockMPU()
+        self.g = _MockGPS()
+
+    def get_sensor_data(self):
+        d = {"ts": time.time()}
+        d.update(self.m.poll() or {})
+        d["gps"] = self.g.poll()
+        return d
+
+# ────────── 로거 유틸 ──────────
+
+def run_logger(rate: float = 10.0, target: int = 1000):
+    sr = SensorReader(); interval = 1.0 / rate
+    ts = int(time.time())
+    json_path = os.path.join(LOG_DIR, f"log_{ts}.jsonl")
+    csv_path  = os.path.join(LOG_DIR, f"log_{ts}.csv")
+
+    fields = ["ts", "ax", "ay", "az", "gx", "gy", "gz", "roll", "pitch", "yaw", "lat", "lon"]
+    with open(json_path, "w") as fj, open(csv_path, "w", newline="") as fc:
+        cw = csv.DictWriter(fc, fieldnames=fields); cw.writeheader()
+        for i in range(target):
+            t0 = time.time(); s = sr.get_sensor_data()
+            fj.write(json.dumps(s) + "\n")
+            row = {k: s.get(k) or s.get('accel', {}).get(k) or s.get('gyro', {}).get(k) or s.get('angle', {}).get(k) or s.get('gps', {}).get(k, '') for k in fields}
+            cw.writerow(row)
+            time.sleep(max(0, interval - (time.time() - t0)))
+    logging.info(f"logged {target} samples → {json_path}, {csv_path}")
+
+if __name__ == "__main__":
+    run_logger()


### PR DESCRIPTION
#### struct 포맷: _FMT = "<Ihhhhhhhhhff" (Little-endian, 총 30 바이트)

("ts",        1),             #(Unsigned Integer, 4 바이트)
-# 타임스템프

("accel.ax",  1000),          # (Signed Short, 2 바이트)
("accel.ay",  1000),        # (Signed Short, 2 바이트)
("accel.az",  1000),    # (Signed Short, 2 바이트)
-# 가속도 xyz 축

("gyro.gx",   10),         # (Signed Short, 2 바이트)
("gyro.gy",   10),        # (Signed Short, 2 바이트)
("gyro.gz",   10),    # (Signed Short, 2 바이트)
-# MPU6050 자이로(Angular velocity) 축별 측정값

("angle.roll", 10),             # (Signed Short, 2 바이트)
("angle.pitch",10),        # (Signed Short, 2 바이트)
("angle.yaw", 10),   # (Signed Short, 2 바이트)
-# MPU6050에서 계산된 회전각(Orientation)

("gps.lat",   1.0),           # (Float, 4 바이트)
("gps.lon",   1.0),          # (Float, 4 바이트)
-# 목업

인코더 디코더 약간의 대격변 제외 문제없음
로깅하고 실제 파일로 기록하는건 나중에 

#### LoRa 페이로드 최대 크기 (MAX_PAYLOAD in encoder.py/sender.py): 56 바이트.
##### [SEQ (1B)] [TOTAL (1B)] [PAYLOAD_CHUNK (최대 56B)]
- LEN (1 바이트): SEQ, TOTAL, PAYLOAD_CHUNK의 전체 길이를 나타내는 1바이트 정수.
- SEQ (1 바이트): 해당 프레임의 시퀀스 번호 (1부터 시작).
- TOTAL (1 바이트): 전체 메시지를 구성하는 총 프레임 수.
- PAYLOAD_CHUNK (가변 길이, 최대 56 바이트): 압축된 센서 데이터의 조각.

#### 프레임 간 전송 딜레이 (DELAY_BETWEEN in sender.py): 0.3 초.
#### 메시지(샘플) 간 전송 딜레이 (sender.py의 send_data 루프 끝): 1.0 초.


#### 핸드셰이크 방식:
- 송신기(Sender)가 SYN 메시지를 전송.
- 수신기(Receiver)가 SYN을 수신하면 ACK 메시지로 응답.
- 핸드셰이크 성공 후, 송신기는 데이터 프레임 전송 시작.
- SYN 메시지 형식: b"SYN\n" (바이트 문자열, 라인 피드 \n으로 종료)
- ACK 메시지 형식: b"ACK\n" (바이트 문자열, 라인 피드 \n으로 종료)

##### 송신기 핸드셰이크 타임아웃 (HANDSHAKE_TIMEOUT in sender.py): 5.0 초 (수신기 대기 시간 고려)
- 이 시간 내에 ACK를 수신하지 못하면 재시도.
##### 송신기 핸드셰이크 재시도 횟수 (RETRY_HANDSHAKE in sender.py): 5 회
- 수신기 SYN 대기 타임아웃 (HANDSHAKE_TO in receiver.py): 5.0 초
이 시간 내에 SYN을 수신하지 못하면 다시 대기 시작.